### PR TITLE
Allow specify unit test result name

### DIFF
--- a/build/RunUnitTests.cmd
+++ b/build/RunUnitTests.cmd
@@ -1,4 +1,6 @@
 @ECHO OFF
 SET CONFIG=%1
+SET LOG_FILE_NAME=%2
 IF '%CONFIG%'=='' SET CONFIG=DEBUG
-dotnet test %~dp0\..\tests\UnitTests\UnitTests.csproj --no-build --logger "trx" -c %CONFIG%
+IF '%LOG_FILE_NAME%'=='' SET LOG_FILE_NAME=TestResults.trx
+dotnet test %~dp0\..\tests\UnitTests\UnitTests.csproj --no-build --logger "trx;LogFileName=%LOG_FILE_NAME%" -c %CONFIG%


### PR DESCRIPTION
This specific test report file name to avoid more than one test results being published.