### PR TITLE
Fix the deadlock when Readiness Probe is configured

### DIFF
--- a/src/Extensions/ApplicationInsightsExtensions.cs
+++ b/src/Extensions/ApplicationInsightsExtensions.cs
@@ -1,7 +1,6 @@
 ﻿namespace Microsoft.Extensions.DependencyInjection
 {
     using System;
-    using System.Linq;
     using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.ApplicationInsights.Kubernetes;
     using Microsoft.Extensions.Logging;
@@ -13,7 +12,8 @@
     {
         public static IServiceCollection EnableKubernetes(this IServiceCollection services, TimeSpan? timeout = null)
         {
-            ILoggerFactory loggerFactory = (ILoggerFactory)services.FirstOrDefault(s => s.ServiceType == typeof(ILoggerFactory))?.ImplementationInstance;
+            IServiceProvider serviceProvider = services.BuildServiceProvider();
+            ILoggerFactory loggerFactory = serviceProvider.GetService<ILoggerFactory>();
             KubernetesModule.EnableKubernetes(TelemetryConfiguration.Active, loggerFactory, timeout);
             return services;
         }


### PR DESCRIPTION
Readiness Probe will disable the communication between the pod and the master until the app is ready; Before the fix, the app will not ready until AI.K8s is initialized; AI.K8s will not be ready until it can talk with master and there we go a dead loop. :-(

The fix simply dispatches the initialization into a different thread so that the main app will still become ready and serves request even when AI.K8s is not yet ready. This might lead to a few initial request telemetry being sent without K8s info, it is still better than the dead loop.

This fix address #73.

Tested with the following configure.
```yaml
apiVersion: extensions/v1beta1
kind: Deployment
metadata:
  name: k8s-debugger
spec:
  replicas: 2
  template:
    metadata:
      labels:
        app: webapp
    spec:
      containers:
        - name: k8s-web
          image: saars/demoapp-in-k8s:0.1.2
          ports:
            - containerPort: 80
          env:
          - name: AI_KEY
            value: whatever-the-ikey-is-for-you:-)
          readinessProbe:
            httpGet:
              path: /Home/About
              port: 80
            initialDelaySeconds: 10
            periodSeconds: 10
            failureThreshold: 10
            timeoutSeconds: 10
```
Notes: initial delay shall be less than the K8s timeout. You can configure the K8s timeout by using the overloads:
```csharp
services.EnableKubernetes(TimeSpan.FromMinutes(5));
```