### PR TITLE
Dev/saars/fix bug serializing telemetry fail

### DIFF
--- a/src/ApplicationInsights.Kubernetes/K8sEnvironmentFactory.cs
+++ b/src/ApplicationInsights.Kubernetes/K8sEnvironmentFactory.cs
@@ -36,7 +36,6 @@ namespace Microsoft.ApplicationInsights.Kubernetes
         public async Task<K8sEnvironment> CreateAsync(TimeSpan timeout)
         {
             K8sEnvironment instance = null;
-            ILogger<K8sEnvironment> logger = null;
 
             try
             {
@@ -53,7 +52,7 @@ namespace Microsoft.ApplicationInsights.Kubernetes
 
                         K8sPod myPod = await queryClient.GetMyPodAsync().ConfigureAwait(false);
                         instance.myPod = myPod;
-                        logger?.LogDebug(Invariant($"Getting container status of container-id: {containerId}"));
+                        _logger.LogDebug(Invariant($"Getting container status of container-id: {containerId}"));
                         instance.myContainerStatus = myPod.GetContainerStatus(containerId);
 
                         IEnumerable<K8sReplicaSet> replicaSetList = await queryClient.GetReplicasAsync().ConfigureAwait(false);
@@ -77,14 +76,14 @@ namespace Microsoft.ApplicationInsights.Kubernetes
                     }
                     else
                     {
-                        logger?.LogError(Invariant($"Kubernetes info is not available within given time of {timeout.TotalMilliseconds} ms."));
+                        _logger.LogError(Invariant($"Kubernetes info is not available within given time of {timeout.TotalMilliseconds} ms."));
                     }
                 }
                 return instance;
             }
             catch (Exception ex)
             {
-                logger?.LogCritical(ex.ToString());
+                _logger.LogCritical(ex.ToString());
                 return null;
             }
         }

--- a/src/ApplicationInsights.Kubernetes/TelemetryInitializers/KubernetesTelemetryInitializer.cs
+++ b/src/ApplicationInsights.Kubernetes/TelemetryInitializers/KubernetesTelemetryInitializer.cs
@@ -4,7 +4,6 @@ using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.ApplicationInsights.Extensibility.Implementation;
 using Microsoft.ApplicationInsights.Kubernetes.Utilities;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
 
 using static Microsoft.ApplicationInsights.Kubernetes.StringUtils;
 
@@ -64,7 +63,6 @@ namespace Microsoft.ApplicationInsights.Kubernetes
 #else
                 SetCustomDimensions(telemetry);
 #endif
-                _logger.LogTrace(JsonConvert.SerializeObject(telemetry));
             }
             else
             {


### PR DESCRIPTION
Address #106. The serialization will happen and fail before the logging. This is especially bad when happens in the telemetry initializer, which supposed to be as lightweight as possible.
I proposal fixing it by pull out the trace totally. It is not worth having a serialization for every telemetry item just for logging even when it does not throw.