### PR TITLE
Dev/saars/refactor init module

### DIFF
--- a/src/ApplicationInsights.Kubernetes/Debuggings/K8sDebuggingEnvironmentFactory.cs
+++ b/src/ApplicationInsights.Kubernetes/Debuggings/K8sDebuggingEnvironmentFactory.cs
@@ -7,9 +7,9 @@ namespace Microsoft.ApplicationInsights.Kubernetes.Debugging
 {
     internal class K8sDebuggingEnvironmentFactory : IK8sEnvironmentFactory
     {
-        public Task<K8sEnvironment> CreateAsync(TimeSpan timeout)
+        public Task<IK8sEnvironment> CreateAsync(TimeSpan timeout)
         {
-            return Task.FromResult(new K8sEnvironment()
+            return Task.FromResult((IK8sEnvironment)new K8sEnvironment()
             {
                 ContainerID = KubeHttpDebuggingClientSettings.FakeContainerId,
                 myContainerStatus = new ContainerStatus()

--- a/src/ApplicationInsights.Kubernetes/Extensions/ApplicationInsightsExtensions.cs
+++ b/src/ApplicationInsights.Kubernetes/Extensions/ApplicationInsightsExtensions.cs
@@ -11,7 +11,9 @@ namespace Microsoft.Extensions.DependencyInjection
     /// </summary>
     public static class ApplicationInsightsExtensions
     {
-        public static IServiceCollection EnableKubernetes(this IServiceCollection services, TimeSpan? timeout = null,
+        public static IServiceCollection EnableKubernetes(
+            this IServiceCollection services, 
+            TimeSpan? timeout = null,
             IKubernetesServiceCollectionBuilder kubernetesServiceCollectionBuilder = null)
         {
             // Dispatch this on a differnet thread to avoid blocking the main thread.
@@ -19,7 +21,7 @@ namespace Microsoft.Extensions.DependencyInjection
             // TODO: Instead of query the server on the start, we should depend on watch services to provide dynamic realtime data.
             Task.Run(() =>
             {
-                KubernetesModule.EnableKubernetes(services, TelemetryConfiguration.Active, timeout, kubernetesServiceCollectionBuilder);
+                KubernetesModule.EnableKubernetes(services, timeout, kubernetesServiceCollectionBuilder);
             });
 
             return services;

--- a/src/ApplicationInsights.Kubernetes/Extensions/IKubernetesServiceCollectionBuilder.cs
+++ b/src/ApplicationInsights.Kubernetes/Extensions/IKubernetesServiceCollectionBuilder.cs
@@ -1,7 +1,9 @@
-﻿namespace Microsoft.Extensions.DependencyInjection
+﻿using System;
+
+namespace Microsoft.Extensions.DependencyInjection
 {
     public interface IKubernetesServiceCollectionBuilder
     {
-        IServiceCollection InjectServices(IServiceCollection serviceCollection);
+        IServiceCollection InjectServices(IServiceCollection serviceCollection, TimeSpan timeout);
     }
 }

--- a/src/ApplicationInsights.Kubernetes/Interfaces/IK8sEnvironmentFactory.cs
+++ b/src/ApplicationInsights.Kubernetes/Interfaces/IK8sEnvironmentFactory.cs
@@ -5,6 +5,6 @@ namespace Microsoft.ApplicationInsights.Kubernetes
 {
     internal interface IK8sEnvironmentFactory
     {
-        Task<K8sEnvironment> CreateAsync(TimeSpan timeout);
+        Task<IK8sEnvironment> CreateAsync(TimeSpan timeout);
     }
 }

--- a/src/ApplicationInsights.Kubernetes/K8sEnvironmentFactory.cs
+++ b/src/ApplicationInsights.Kubernetes/K8sEnvironmentFactory.cs
@@ -33,7 +33,7 @@ namespace Microsoft.ApplicationInsights.Kubernetes
         /// Async factory method to build the instance of a K8sEnvironment.
         /// </summary>
         /// <returns></returns>
-        public async Task<K8sEnvironment> CreateAsync(TimeSpan timeout)
+        public async Task<IK8sEnvironment> CreateAsync(TimeSpan timeout)
         {
             K8sEnvironment instance = null;
 

--- a/src/ApplicationInsights.Kubernetes/TelemetryInitializers/KubernetesModule.cs
+++ b/src/ApplicationInsights.Kubernetes/TelemetryInitializers/KubernetesModule.cs
@@ -31,13 +31,15 @@ namespace Microsoft.ApplicationInsights.Kubernetes
         {
             // Temporary fix to make sure that we initialize module once.
             // It should be removed when configuration reading logic is moved to Web SDK.
-            if (!isInitialized)
+            if (!_isInitialized)
             {
                 lock (lockObject)
                 {
-                    if (!isInitialized)
+                    if (!_isInitialized)
                     {
-                        EnableKubernetes(null, configuration, timeout);
+                        // Configuration is required to work with Application Insights.
+                        Arguments.IsNotNull(configuration, nameof(configuration));
+                        EnableKubernetes(null, timeout: timeout);
                     }
                 }
             }
@@ -49,63 +51,38 @@ namespace Microsoft.ApplicationInsights.Kubernetes
         /// <param name="loggerFactory"></param>
         /// <param name="timeout"></param>
         public static void EnableKubernetes(IServiceCollection serviceCollection,
-            TelemetryConfiguration configuration,
             TimeSpan? timeout = null,
             IKubernetesServiceCollectionBuilder kubernetesServiceCollectionBuilder = null)
         {
             // 2 minutes maximum to spin up the container.
             timeout = timeout ?? TimeSpan.FromMinutes(2);
 
-            serviceCollection = BuildK8sServiceCollection(serviceCollection, kubernetesServiceCollectionBuilder);
             IServiceProvider serviceProvider = serviceCollection.BuildServiceProvider();
             ILogger logger = serviceProvider.GetService<ILogger<KubernetesModule>>();
-
-            Task.Run(() =>
-            {
-                try
-                {
-                    string versionInfo = typeof(ApplicationInsightsExtensions).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
-                    logger.LogInformation(Invariant($"ApplicationInsights.Kubernetes.Version:{versionInfo}"));
-                }
-                catch (Exception ex)
-                {
-                    logger.LogError("Failed to fetch ApplicaitonInsights.Kubernetes' version info. Details" + ex.ToString());
-                }
-            });
-
+            logger.LogInformation(Invariant($"ApplicationInsights.Kubernetes.Version:{SDKVersionUtils.Instance.CurrentSDKVersion}"));
             try
             {
-                K8sEnvironment k8sEnv = serviceProvider.GetRequiredService<IK8sEnvironmentFactory>().CreateAsync(timeout.Value).ConfigureAwait(false).GetAwaiter().GetResult();
-                if (k8sEnv != null)
-                {
-                    // Inject the telemetry initializer.
-                    ITelemetryInitializer initializer = new KubernetesTelemetryInitializer(k8sEnv,
-                        SDKVersionUtils.Instance,
-                        serviceProvider.GetService<ILogger<KubernetesTelemetryInitializer>>());
-                    configuration.TelemetryInitializers.Add(initializer);
-                    logger?.LogDebug("Application Insights Kubernetes injected the service successfully.");
-                }
-                else
-                {
-                    logger?.LogError("Application Insights Kubernetes failed to start.");
-                }
-                isInitialized = true;
+                serviceCollection = BuildK8sServiceCollection(serviceCollection, timeout.Value, kubernetesServiceCollectionBuilder);
             }
             catch (Exception ex)
             {
-                logger?.LogError(ex.ToString());
+                logger.LogError("Failed to fetch ApplicaitonInsights.Kubernetes' version info. Details" + ex.ToString());
             }
+            _isInitialized = true;
         }
 
-        internal static IServiceCollection BuildK8sServiceCollection(IServiceCollection services, IKubernetesServiceCollectionBuilder kubernetesServiceCollectionBuilder = null)
+        internal static IServiceCollection BuildK8sServiceCollection(
+            IServiceCollection services,
+            TimeSpan timeout,
+            IKubernetesServiceCollectionBuilder kubernetesServiceCollectionBuilder = null)
         {
             kubernetesServiceCollectionBuilder = kubernetesServiceCollectionBuilder ?? new KubernetesServiceCollectionBuilder();
-            Services = kubernetesServiceCollectionBuilder.InjectServices(services);
+            Services = kubernetesServiceCollectionBuilder.InjectServices(services, timeout);
             return Services;
         }
 
         private static readonly object lockObject = new object();
-        private static bool isInitialized = false;
+        private static bool _isInitialized = false;
         internal static IServiceCollection Services { get; private set; }
     }
 }

--- a/tests/UnitTests/KubernetesModuleTests.cs
+++ b/tests/UnitTests/KubernetesModuleTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.ApplicationInsights.Netcore.Kubernetes
         public void ServiceInjected()
         {
             IServiceCollection services = new ServiceCollection();
-            services = KubernetesModule.BuildK8sServiceCollection(services);
+            services = KubernetesModule.BuildK8sServiceCollection(services, TimeSpan.Zero);
 
             // Replace the IKubeHttpClientSetingsProvider in case the test is not running inside a container.
             Assert.NotNull(services.FirstOrDefault(s => s.ServiceType == typeof(IKubeHttpClientSettingsProvider)));

--- a/tests/UnitTests/KubernetesTelemtryInitializerTests.cs
+++ b/tests/UnitTests/KubernetesTelemtryInitializerTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.ApplicationInsights.Kubernetes.Utilities;
@@ -11,25 +12,29 @@ namespace Microsoft.ApplicationInsights.Kubernetes
 {
     public class KubernetesTelemtryInitializerTests
     {
-        [Fact(DisplayName = "K8sEnv can't be null in K8sTelemetryInitializer")]
+        [Fact(DisplayName = "K8sEnvFactory can't be null in K8sTelemetryInitializer")]
         public void ConstructorSetsNullGetsNull()
         {
             Exception ex = Assert.Throws<ArgumentNullException>(() =>
             {
-                KubernetesTelemetryInitializer target = new KubernetesTelemetryInitializer(null, SDKVersionUtils.Instance, GetLogger());
+                KubernetesTelemetryInitializer target = new KubernetesTelemetryInitializer(null, TimeSpan.Zero, SDKVersionUtils.Instance, GetLogger());
             });
 
-            Assert.Equal("Value cannot be null.\r\nParameter name: k8sEnv", ex.Message);
+            Assert.Equal("Value cannot be null.\r\nParameter name: k8sEnvFactory", ex.Message);
         }
 
         [Fact(DisplayName = "K8sTelemetryInitializer sets the K8s env correct")]
         public void ConstructorSetK8sEnvironment()
         {
             var envMock = new Mock<IK8sEnvironment>();
-            KubernetesTelemetryInitializer target = new KubernetesTelemetryInitializer(envMock.Object, SDKVersionUtils.Instance, GetLogger());
+            var factoryMock = new Mock<IK8sEnvironmentFactory>();
+            factoryMock.Setup(f => f.CreateAsync(It.IsAny<TimeSpan>())).ReturnsAsync(() => envMock.Object);
+           
+            KubernetesTelemetryInitializer target = new KubernetesTelemetryInitializer(factoryMock.Object, TimeSpan.Zero, SDKVersionUtils.Instance, GetLogger());
 
-            Assert.NotNull(target.K8sEnvironment);
-            Assert.Equal(envMock.Object, target.K8sEnvironment);
+            Assert.NotNull(target._k8sEnvironment);
+            Assert.Equal(factoryMock.Object, target._k8sEnvFactory);
+            Assert.Equal(envMock.Object, target._k8sEnvironment);
         }
 
         [Fact(DisplayName = "K8sTelemetryInitializer sets the cloud_RoleName")]
@@ -37,7 +42,10 @@ namespace Microsoft.ApplicationInsights.Kubernetes
         {
             var envMock = new Mock<IK8sEnvironment>();
             envMock.Setup(env => env.ContainerName).Returns("Hello RoleName");
-            KubernetesTelemetryInitializer target = new KubernetesTelemetryInitializer(envMock.Object, SDKVersionUtils.Instance, GetLogger());
+            var envFactoryMock = new Mock<IK8sEnvironmentFactory>();
+            envFactoryMock.Setup(f => f.CreateAsync(It.IsAny<TimeSpan>())).ReturnsAsync(() => envMock.Object);
+            
+            KubernetesTelemetryInitializer target = new KubernetesTelemetryInitializer(envFactoryMock.Object, TimeSpan.Zero, SDKVersionUtils.Instance, GetLogger());
             ITelemetry telemetry = new TraceTelemetry();
             target.Initialize(telemetry);
 
@@ -49,7 +57,10 @@ namespace Microsoft.ApplicationInsights.Kubernetes
         {
             var envMock = new Mock<IK8sEnvironment>();
             envMock.Setup(env => env.ContainerName).Returns("New RoleName");
-            KubernetesTelemetryInitializer target = new KubernetesTelemetryInitializer(envMock.Object, SDKVersionUtils.Instance, GetLogger());
+            var envFactoryMock = new Mock<IK8sEnvironmentFactory>();
+            envFactoryMock.Setup(f => f.CreateAsync(It.IsAny<TimeSpan>())).ReturnsAsync(() => envMock.Object);
+
+            KubernetesTelemetryInitializer target = new KubernetesTelemetryInitializer(envFactoryMock.Object, TimeSpan.Zero, SDKVersionUtils.Instance, GetLogger());
             ITelemetry telemetry = new TraceTelemetry();
             telemetry.Context.Cloud.RoleName = "Existing RoleName";
             target.Initialize(telemetry);
@@ -75,7 +86,10 @@ namespace Microsoft.ApplicationInsights.Kubernetes
             envMock.Setup(env => env.NodeUid).Returns("Nid");
             envMock.Setup(env => env.NodeName).Returns("NName");
 
-            KubernetesTelemetryInitializer target = new KubernetesTelemetryInitializer(envMock.Object, SDKVersionUtils.Instance, GetLogger());
+            var envFactoryMock = new Mock<IK8sEnvironmentFactory>();
+            envFactoryMock.Setup(f => f.CreateAsync(It.IsAny<TimeSpan>())).ReturnsAsync(() => envMock.Object);
+
+            KubernetesTelemetryInitializer target = new KubernetesTelemetryInitializer(envFactoryMock.Object, TimeSpan.Zero, SDKVersionUtils.Instance, GetLogger());
             ITelemetry telemetry = new TraceTelemetry();
             target.Initialize(telemetry);
 
@@ -104,10 +118,12 @@ namespace Microsoft.ApplicationInsights.Kubernetes
         {
             var envMock = new Mock<IK8sEnvironment>();
             envMock.Setup(env => env.ContainerName).Returns("Hello RoleName");
-
             envMock.Setup(env => env.ContainerID).Returns("Cid");
 
-            KubernetesTelemetryInitializer target = new KubernetesTelemetryInitializer(envMock.Object, SDKVersionUtils.Instance, GetLogger());
+            var envFactoryMock = new Mock<IK8sEnvironmentFactory>();
+            envFactoryMock.Setup(f => f.CreateAsync(It.IsAny<TimeSpan>())).ReturnsAsync(() => envMock.Object);
+
+            KubernetesTelemetryInitializer target = new KubernetesTelemetryInitializer(envFactoryMock.Object, TimeSpan.Zero, SDKVersionUtils.Instance, GetLogger());
             ITelemetry telemetry = new TraceTelemetry();
             telemetry.Context.Properties["K8s.Container.ID"] = "Existing Cid";
             target.Initialize(telemetry);


### PR DESCRIPTION
Address #109 .
Basically, the idea is: allow the TelemetryModel and the ITelemetryInitializer finish injected to the service collection. Spin up the query for the K8s properties but delay do NOT be blocked by the result.
When there's no result and not timeout yet, skip the initializer for the telemetry until:
1. there's K8s info;
2. timeout.
When it times out, log an error.