### PR TITLE
Reference MicroBuild 0.3.0 to support nuget package sign

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -32,7 +32,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(IsCIBuild)' == 'true' ">
-    <PackageReference Include="MicroBuild.Core" Version="0.2.0">
+    <PackageReference Include="MicroBuild.Core" Version="0.3.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>


### PR DESCRIPTION
Address #110 .
NuGet package sign requires MicroBuild 0.3.0 and above to works for multi-targeting project like the ApplicationInsights.Kubernetes package.

