### PR TITLE
Update documentation EnableKubernetes

### DIFF
--- a/src/ApplicationInsights.Kubernetes/Extensions/ApplicationInsightsExtensions.cs
+++ b/src/ApplicationInsights.Kubernetes/Extensions/ApplicationInsightsExtensions.cs
@@ -18,10 +18,10 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <summary>
         /// Enable Application Insights Kubernetes for the Default TelemtryConfiguration in the dependency injection system.
         /// </summary>
-        /// <param name="services"></param>
-        /// <param name="timeout"></param>
-        /// <param name="kubernetesServiceCollectionBuilder"></param>
-        /// <returns></returns>
+        /// <param name="services">Collection of service descriptors</param>
+        /// <param name="timeout">Maximum time to wait for spinning up the container</param>
+        /// <param name="kubernetesServiceCollectionBuilder">Collection builder</param>
+        /// <returns>The collection of services descripters we injected into</returns>
         public static IServiceCollection EnableKubernetes(
             this IServiceCollection services,
             TimeSpan? timeout = null,
@@ -34,10 +34,15 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         /// <summary>
-        /// Enable Application Insights Kubernetes for a given TelemetryConfiguration.
-        /// Note: The use of EnableKubernetes() on the ServiceCollection is always preferred unless you have more than one
-        /// TelemetryConfiguration instances.
+        /// Enable Application Insights Kubernetes for a given
+        /// TelemetryConfiguration.
         /// </summary>
+        /// <remarks>
+        /// The use of EnableKubernetes() on the ServiceCollection is always
+        /// preferred unless you have more than one TelemetryConfiguration
+        /// instance, or if you are using Application Insights from a non ASP.NET
+        /// environment, like a console app.
+        /// </remarks>
         public static void EnableKubernetes(
             this TelemetryConfiguration telemetryConfiguration,
             TimeSpan? timeout = null,


### PR DESCRIPTION
This commit will update the documentation of
ApplicationInsightsExtensions.Enablekubernetes with information that
this method can be used to inject the Kubernetes telemetry initializer
if you are running in a non ASP.NET environment, like a console app
for example.