### PR TITLE
Update package versions

### DIFF
--- a/examples/BasicUsage/BasicUsage.csproj
+++ b/examples/BasicUsage/BasicUsage.csproj
@@ -6,14 +6,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.2.1" />
-    <PackageReference Include="Microsoft.ApplicationInsights.Kubernetes" Version="1.0.0-beta6" />
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.6" />
-    <PackageReference Include="Microsoft.AspNetCore.Antiforgery" Version="2.0.2" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.2.*" />
+    <PackageReference Include="Microsoft.ApplicationInsights.Kubernetes" Version="1.0.*" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.*" />
+    <PackageReference Include="Microsoft.AspNetCore.Antiforgery" Version="2.0.*" />
   </ItemGroup>
 
   <ItemGroup>
-    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.3" />
+    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.*" />
   </ItemGroup>
 
 </Project>

--- a/examples/BasicUsage/README.md
+++ b/examples/BasicUsage/README.md
@@ -10,7 +10,7 @@ dotnet new mvc
 * Add the NuGet Packages:
 ```
 dotnet add package Microsoft.ApplicationInsights.AspNetCore
-dotnet add package Microsoft.ApplicationInsights.Kubernetes --version 1.0.0-*
+dotnet add package Microsoft.ApplicationInsights.Kubernetes
 ```
 
 * Edit the project file, add the following property:

--- a/examples/BasicUsage_clr21_RBAC/README.MD
+++ b/examples/BasicUsage_clr21_RBAC/README.MD
@@ -36,7 +36,7 @@ dotnet new mvc
 * Add the NuGet Packages:
 ```
 dotnet add package Microsoft.ApplicationInsights.AspNetCore
-dotnet add package Microsoft.ApplicationInsights.Kubernetes --version 1.0.0-*
+dotnet add package Microsoft.ApplicationInsights.Kubernetes
 ```
 
 * Enable Application Insights in Program.cs by calling UseApplicaitonInsights() on WebHostBuilder:

--- a/examples/BasicUsage_clr21_RBAC/app/app.csproj
+++ b/examples/BasicUsage_clr21_RBAC/app/app.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.3.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights.Kubernetes" Version="1.0.0-beta8" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.3.*" />
+    <PackageReference Include="Microsoft.ApplicationInsights.Kubernetes" Version="1.0.*" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 

--- a/examples/MultipleIKeys/MultipleIKeys.csproj
+++ b/examples/MultipleIKeys/MultipleIKeys.csproj
@@ -6,13 +6,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.6" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.2.1" />
-    <PackageReference Include="Microsoft.ApplicationInsights.Kubernetes" Version="1.0.0-beta8" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.*" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.2.*" />
+    <PackageReference Include="Microsoft.ApplicationInsights.Kubernetes" Version="1.0.*" />
   </ItemGroup>
 
   <ItemGroup>
-    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.3" />
+    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.*" />
   </ItemGroup>
 
 </Project>

--- a/examples/MultipleIKeys/Startup.cs
+++ b/examples/MultipleIKeys/Startup.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;

--- a/examples/WindowsContainer/AspNetCoreNano.csproj
+++ b/examples/WindowsContainer/AspNetCoreNano.csproj
@@ -6,13 +6,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights.Kubernetes" Version="1.0.0-private-201804252038" />
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.6" />
-    <PackageReference Include="Microsoft.AspNetCore.Antiforgery" Version="2.0.2" />
+    <PackageReference Include="Microsoft.ApplicationInsights.Kubernetes" Version="1.0.*" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.*" />
+    <PackageReference Include="Microsoft.AspNetCore.Antiforgery" Version="2.0.*" />
   </ItemGroup>
 
   <ItemGroup>
-    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.3" />
+    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.*" />
   </ItemGroup>
 
 </Project>

--- a/examples/WindowsContainer/README.md
+++ b/examples/WindowsContainer/README.md
@@ -9,7 +9,7 @@ dotnet new mvc
 * Add the NuGet Packages:
 ```
 dotnet add package Microsoft.ApplicationInsights.AspNetCore
-dotnet add package Microsoft.ApplicationInsights.Kubernetes --version 1.0.0-*
+dotnet add package Microsoft.ApplicationInsights.Kubernetes
 ```
 
 * Edit the [project file](AspNetCoreNano.csproj), add the following property:

--- a/examples/ZeroUserCodeLightup/Dockerfile
+++ b/examples/ZeroUserCodeLightup/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 # Copy everything else and build
 COPY . ./
 # Adding a reference to hosting startup package
-RUN dotnet add package Microsoft.ApplicationInsights.Kubernetes.HostingStartup -v 1.0.0-*
+RUN dotnet add package Microsoft.ApplicationInsights.Kubernetes.HostingStartup
 RUN dotnet publish -c Release -o out
 
 # Build runtime image

--- a/examples/ZeroUserCodeLightup/README.md
+++ b/examples/ZeroUserCodeLightup/README.md
@@ -8,7 +8,7 @@ All you need to do is to add a few lines in the [Dockerfile](./Dockerfile), and 
 ```dockerfile
 ...
 # Adding a reference to hosting startup package
-RUN dotnet add package Microsoft.ApplicationInsights.Kubernetes.HostingStartup  -v 1.0.0-*
+RUN dotnet add package Microsoft.ApplicationInsights.Kubernetes.HostingStartup
 
 # Light up Application Insights for Kubernetes
 ENV APPINSIGHTS_INSTRUMENTATIONKEY $APPINSIGHTS_KEY

--- a/examples/ZeroUserCodeLightup/ZeroUserCodeLightup.csproj
+++ b/examples/ZeroUserCodeLightup/ZeroUserCodeLightup.csproj
@@ -5,11 +5,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.*" />
   </ItemGroup>
 
   <ItemGroup>
-    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.2" />
+    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.*" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Addresses #142 

1. Address vulnerability issues by bumping up external package versions in the examples.
2. Bump up the references to the NuGet package of AI.K8S itself to the latest non-prerelease version.