### PR TITLE
Dev/saars/daemon set

### DIFF
--- a/src/ApplicationInsights.Kubernetes/TelemetryInitializers/KubernetesTelemetryInitializer.cs
+++ b/src/ApplicationInsights.Kubernetes/TelemetryInitializers/KubernetesTelemetryInitializer.cs
@@ -124,10 +124,10 @@ namespace Microsoft.ApplicationInsights.Kubernetes
 
             // Pod will have no replica name or deployment when deployed through other means. For example, as a daemonset.
             // Replica Set
-            SetCustomDimension(telemetry, Invariant($"{K8s}.{ReplicaSet}.Name"), this._k8sEnvironment.ReplicaSetName, true);
+            SetCustomDimension(telemetry, Invariant($"{K8s}.{ReplicaSet}.Name"), this._k8sEnvironment.ReplicaSetName, isValueOptional: true);
 
             // Deployment
-            SetCustomDimension(telemetry, Invariant($"{K8s}.{Deployment}.Name"), this._k8sEnvironment.DeploymentName, true);
+            SetCustomDimension(telemetry, Invariant($"{K8s}.{Deployment}.Name"), this._k8sEnvironment.DeploymentName, isValueOptional: true);
 
             // Ndoe
             SetCustomDimension(telemetry, Invariant($"{K8s}.{Node}.ID"), this._k8sEnvironment.NodeUid);

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -15,8 +15,8 @@
         <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)PublicKey.snk</AssemblyOriginatorKeyFile>
         <!--Package-->
         <VersionSuffix Condition=" '$(VersionSuffix)' == '' ">$([System.DateTime]::Now.ToString(yyyyMMddHHmm))</VersionSuffix>
-        <Version Condition=" '$(Version)' == '' ">1.0.0-private-$(VersionSuffix)</Version>
-        <AssemblyVersion Condition=" '$(AssemblyVersion)' == '' " >1.0.0.0</AssemblyVersion>
+        <Version Condition=" '$(Version)' == '' ">1.0.1-private-$(VersionSuffix)</Version>
+        <AssemblyVersion Condition=" '$(AssemblyVersion)' == '' " >1.0.1.0</AssemblyVersion>
         <Authors>Microsoft</Authors>
         <Company>Microsoft</Company>
         <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>


### PR DESCRIPTION
Address #145 
For pod created in DaemonSet, there's no ReplicaSet or Deployment available.
Since this info is not always available, they are made optional in this change.