### PR TITLE
[proposal] change cluster role name from metrics-reader to ai-k8s-role

### DIFF
--- a/examples/BasicUsage_clr21_RBAC/README.MD
+++ b/examples/BasicUsage_clr21_RBAC/README.MD
@@ -69,7 +69,7 @@ docker push dockeraccount/aik8sbasic_rbac:latest
 ```
 ## Setup the default Service Account for RBAC enabled cluster
 * If the cluster is RBAC enabled, the service account used will need to bind to proper cluster role so that the application can fetch Kubernetes related properties.
-In [saRole.yaml](k8s/saRole.yaml), a cluster role named `metrics-reader` is created and then bind to the default service account. Permissions needed are listed in the resources property. To deploy it, update the value for the `namespace` and then:
+In [saRole.yaml](k8s/saRole.yaml), a cluster role named `appinsights-k8s-property-reader` is created and then bind to the default service account. Permissions needed are listed in the resources property. To deploy it, update the value for the `namespace` and then:
 ```
 kubectl create -f k8s/saRole.yaml
 ```

--- a/examples/BasicUsage_clr21_RBAC/k8s/saRole.yaml
+++ b/examples/BasicUsage_clr21_RBAC/k8s/saRole.yaml
@@ -2,7 +2,7 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   # "namespace" omitted since ClusterRoles are not namespaced
-  name: metrics-reader
+  name: appinsights-k8s-property-reader
 rules:
 - apiGroups: ["","extensions"]
   resources: ["pods","nodes", "replicasets","deployments"]
@@ -12,13 +12,13 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: metrics-reader-binding
+  name: appinsights-k8s-property-reader-binding
 subjects:
 - kind: ServiceAccount
   name: default
   namespace: YOUR-NAMESPACE
 roleRef:
   kind: ClusterRole
-  name: metrics-reader
+  name: appinsights-k8s-property-reader
   apiGroup: rbac.authorization.k8s.io
 

--- a/examples/WindowsContainer/README.md
+++ b/examples/WindowsContainer/README.md
@@ -89,7 +89,7 @@ docker push dockeraccount/aspnetcorenano:latest
 
 ## Setup the default Service Account for RBAC enabled cluster
 
-* If the cluster is RBAC enabled, the service account used will need to bind to proper cluster role so that the application can fetch Kubernetes related properties. In [saRole.yaml](./k8s/saRole.yaml), a cluster role named metrics-reader is created and then bind to the default service account. Permissions needed are listed in the resources property. To deploy it, update the value for the namespace and then:
+* If the cluster is RBAC enabled, the service account used will need to bind to proper cluster role so that the application can fetch Kubernetes related properties. In [saRole.yaml](./k8s/saRole.yaml), a cluster role named appinsights-k8s-property-reader is created and then bind to the default service account. Permissions needed are listed in the resources property. To deploy it, update the value for the namespace and then:
 
 ```shell
 kubectl create -f k8s/saRole.yaml

--- a/examples/WindowsContainer/k8s/saRole.yaml
+++ b/examples/WindowsContainer/k8s/saRole.yaml
@@ -2,7 +2,7 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   # "namespace" omitted since ClusterRoles are not namespaced
-  name: metrics-reader
+  name: appinsights-k8s-property-reader
 rules:
 - apiGroups: ["","extensions"]
   resources: ["pods","nodes", "replicasets","deployments"]
@@ -12,13 +12,13 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: metrics-reader-binding
+  name: appinsights-k8s-property-reader-binding
 subjects:
 - kind: ServiceAccount
   name: default
   namespace: YOUR-NAMESPACE
 roleRef:
   kind: ClusterRole
-  name: metrics-reader
+  name: appinsights-k8s-property-reader
   apiGroup: rbac.authorization.k8s.io
 


### PR DESCRIPTION
At first glance in some examples I couldn't find a correlation between the RBAC cluster role name ```metrics-reader``` and what I understand this role is actually being used for: _"fetch Kubernetes related properties"_ 

That being said, please let me propose changing its name to ```ai-k8s-role```.