### PR TITLE
solve AppInsights-K8s compat issue with MEL

### DIFF
--- a/src/ApplicationInsights.Kubernetes/Extensions/ApplicationInsightsExtensions.cs
+++ b/src/ApplicationInsights.Kubernetes/Extensions/ApplicationInsightsExtensions.cs
@@ -25,7 +25,10 @@ namespace Microsoft.Extensions.DependencyInjection
         public static IServiceCollection AddApplicationInsightsKubernetesEnricher(
             this IServiceCollection services)
         {
-            return services.AddApplicationInsightsKubernetesEnricher(applyOptions: null);
+            return services.Configure<TelemetryConfiguration>(
+                (config) =>
+                    config.AddApplicationInsightsKubernetesEnricher(
+                            applyOptions: null));
         }
 
         /// <summary>


### PR DESCRIPTION
configure k8s enricher for a given TelemetryConfiguration as default
instead of adding it in the dependency injection system.

important: the configuration will be invoked at a different point in time during
the host building proccess (pipeline).

it prevents circular dependencies issues while using Microsoft Extensions Logging
for Application Insights and should be backwards compat.

solved: #173