### PR TITLE
use the app's config providers for Zero Light Up

### DIFF
--- a/src/ApplicationInsights.Kubernetes.HostingStartup/K8sInjection.cs
+++ b/src/ApplicationInsights.Kubernetes.HostingStartup/K8sInjection.cs
@@ -14,10 +14,11 @@ namespace ApplicationInsights.Kubernetes.HostingStartup
         /// <param name="builder">The web host builder.</param>
         public void Configure(IWebHostBuilder builder)
         {
-            builder.UseApplicationInsights()
-                .ConfigureServices(services =>
+            builder
+                .ConfigureServices((ctxt, services) =>
                 {
                     services.AddApplicationInsightsKubernetesEnricher();
+                    services.AddApplicationInsightsTelemetry(ctxt.Configuration);
                 });
         }
     }


### PR DESCRIPTION
now K8sInjection will use the the app's configuration providers in addition
to those added automatically by CreateDefaultBuilder

   - remove UseApplicationInsights in favor of adding
   - enable users to configure its app using other providers like
     AzureKeyVaultConfigurationProvider

Important: configuration providers are available at IHostingStartup
           configure time provided they are added as App Configuration.
           For more information, please take a look at https://docs.microsoft.com/en-us/aspnet/core/fundamentals/configuration/?view=aspnetcore-2.2#configureappconfiguration

Solved: #175