### PR TITLE
Downgrade dependencies

### DIFF
--- a/src/ApplicationInsights.Kubernetes/ApplicationInsights.Kubernetes.csproj
+++ b/src/ApplicationInsights.Kubernetes/ApplicationInsights.Kubernetes.csproj
@@ -18,11 +18,11 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.16.0" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.14" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.14" />
+    <PackageReference Include="Microsoft.Extensions.DiagnosticAdapter" Version="3.1.14" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.14" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DiagnosticAdapter" Version="3.1.13" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This will address #228 by limited test in Azure Function environment.
Considering:

* .NET Core 3.1 LTS still have a long lifetime, 
* We aren't use any 5.x specific APIs.

It isn't bad to lower the entrance for Azure Functions.