### PR TITLE
Avoid building pre-mature service provider

### DIFF
--- a/src/ApplicationInsights.Kubernetes/Debuggings/KubernetesDebuggingServiceCollectionBuilder.cs
+++ b/src/ApplicationInsights.Kubernetes/Debuggings/KubernetesDebuggingServiceCollectionBuilder.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
 namespace Microsoft.ApplicationInsights.Kubernetes.Debugging
@@ -13,7 +12,7 @@ namespace Microsoft.ApplicationInsights.Kubernetes.Debugging
         /// Constructor for <see cref="KubernetesDebuggingServiceCollectionBuilder"/>.
         /// </summary>
         public KubernetesDebuggingServiceCollectionBuilder(IOptions<AppInsightsForKubernetesOptions> options)
-        : base(isRunningInKubernetes: () => true, options) { }
+        : base(isRunningInKubernetes: () => true) { }
 
         /// <summary>
         /// Registers setttings provider for querying K8s proxy.

--- a/src/ApplicationInsights.Kubernetes/Extensions/ApplicationInsightsExtensions.cs
+++ b/src/ApplicationInsights.Kubernetes/Extensions/ApplicationInsightsExtensions.cs
@@ -124,9 +124,7 @@ namespace Microsoft.Extensions.DependencyInjection
             IKubernetesServiceCollectionBuilder kubernetesServiceCollectionBuilder = null)
         {
             detectKubernetes ??= IsRunningInKubernetes;
-            using ServiceProvider provider = services.BuildServiceProvider();
-            var options = provider.GetRequiredService<IOptions<AppInsightsForKubernetesOptions>>();
-            kubernetesServiceCollectionBuilder ??= new KubernetesServiceCollectionBuilder(detectKubernetes, options);
+            kubernetesServiceCollectionBuilder ??= new KubernetesServiceCollectionBuilder(detectKubernetes);
             kubernetesServiceCollectionBuilder.RegisterServices(services);
         }
 

--- a/src/ApplicationInsights.Kubernetes/Extensions/KubernetesServiceCollectionBuilder.cs
+++ b/src/ApplicationInsights.Kubernetes/Extensions/KubernetesServiceCollectionBuilder.cs
@@ -4,7 +4,6 @@ using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.ApplicationInsights.Kubernetes;
 using Microsoft.ApplicationInsights.Kubernetes.Debugging;
 using Microsoft.ApplicationInsights.Kubernetes.Utilities;
-using Microsoft.Extensions.Options;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -14,20 +13,16 @@ namespace Microsoft.Extensions.DependencyInjection
     public class KubernetesServiceCollectionBuilder : IKubernetesServiceCollectionBuilder
     {
         private readonly Func<bool> _isRunningInKubernetes;
-        private readonly AppInsightsForKubernetesOptions _options;
         private readonly ApplicationInsightsKubernetesDiagnosticSource _logger = ApplicationInsightsKubernetesDiagnosticSource.Instance;
 
         /// <summary>
         /// Construction for <see cref="KubernetesServiceCollectionBuilder"/>.
         /// </summary>
         /// <param name="isRunningInKubernetes">A function that returns true when running inside Kubernetes.</param>
-        /// <param name="options"></param>
         public KubernetesServiceCollectionBuilder(
-            Func<bool> isRunningInKubernetes,
-            IOptions<AppInsightsForKubernetesOptions> options)
+            Func<bool> isRunningInKubernetes)
         {
             _isRunningInKubernetes = isRunningInKubernetes ?? throw new ArgumentNullException(nameof(isRunningInKubernetes));
-            _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
         }
 
         /// <summary>
@@ -61,14 +56,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
         private void RegisterPerformanceCounterTelemetryInitializer(IServiceCollection serviceCollection)
         {
-            if (!_options.DisablePerformanceCounters)
-            {
-                serviceCollection.AddSingleton<ITelemetryInitializer, SimplePerformanceCounterTelemetryInitializer>();
-            }
-            else
-            {
-                _logger.LogDebug("{initializerName} is disabled by configuration.", nameof(SimplePerformanceCounterTelemetryInitializer));
-            }
+            serviceCollection.AddSingleton<ITelemetryInitializer, SimplePerformanceCounterTelemetryInitializer>();
         }
 
         private static void RegisterCommonServices(IServiceCollection serviceCollection)

--- a/tests/UnitTests/KubernetesTestServiceCollectionBuilder.cs
+++ b/tests/UnitTests/KubernetesTestServiceCollectionBuilder.cs
@@ -7,7 +7,7 @@ namespace Microsoft.ApplicationInsights.Kubernetes
     internal class KubernetesTestServiceCollectionBuilder : KubernetesServiceCollectionBuilder
     {
         public KubernetesTestServiceCollectionBuilder()
-            : base(isRunningInKubernetes: () => true, Options.Create(new AppInsightsForKubernetesOptions()))
+            : base(isRunningInKubernetes: () => true)
         {
         }
 


### PR DESCRIPTION
Address #236.

The issue is caused by the fact a pre-matured service provider is built during the service registration. Bad practice:
Code:
https://github.com/microsoft/ApplicationInsights-Kubernetes/blob/ad6974f1c994c3f48e6ce11e779b878a7203c92a/src/ApplicationInsights.Kubernetes/Extensions/ApplicationInsightsExtensions.cs#L127
