### PR TITLE
Dev/saars/normalize container

### DIFF
--- a/src/ApplicationInsights.Kubernetes/ContainerIdProviders/ContainerIdNormalizer.cs
+++ b/src/ApplicationInsights.Kubernetes/ContainerIdProviders/ContainerIdNormalizer.cs
@@ -1,0 +1,44 @@
+#nullable enable
+
+using System;
+using System.Text.RegularExpressions;
+using Microsoft.ApplicationInsights.Kubernetes.Debugging;
+
+namespace Microsoft.ApplicationInsights.Kubernetes.ContainerIdProviders;
+
+/// <summary>
+/// A simple container id normalizer that picks out 64 digits of GUID/UUID from a container id with prefix / suffix.
+/// For example:
+/// cri-containerd-5146b2bcd77ab4f2624bc1fbd98cf9751741344a80b043dbd77a4e847bff4f06.scope will be normalized to
+/// 5146b2bcd77ab4f2624bc1fbd98cf9751741344a80b043dbd77a4e847bff4f06
+/// </summary>
+internal class ContainerIdNormalizer : IContainerIdNormalizer
+{
+    // Simple rule: 64-characters GUID/UUID.
+    private const string ContainerIdIdentifierPattern = @"[a-f0-9]{64}";
+    private readonly Regex _matcher = new Regex(ContainerIdIdentifierPattern, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant, matchTimeout: TimeSpan.FromSeconds(1));
+    private readonly ApplicationInsightsKubernetesDiagnosticSource _logger = ApplicationInsightsKubernetesDiagnosticSource.Instance;
+
+
+    public bool TryNormalize(string input, out string? normalized)
+    {
+        if (string.IsNullOrEmpty(input))
+        {
+            throw new ArgumentException($"'{nameof(input)}' cannot be null or empty.", nameof(input));
+        }
+
+        _logger.LogDebug($"Normalize container id: {input}");
+
+        Match match = _matcher.Match(input);
+        if (!match.Success)
+        {
+            _logger.LogDebug($"Failed match any container id by pattern: {ContainerIdIdentifierPattern}.");
+            normalized = null;
+            return false;
+        }
+        normalized = match.Value;
+        _logger.LogTrace($"Container id normalized to: {normalized}");
+        return true;
+    }
+}
+

--- a/src/ApplicationInsights.Kubernetes/ContainerIdProviders/IContainerIdNormalizer.cs
+++ b/src/ApplicationInsights.Kubernetes/ContainerIdProviders/IContainerIdNormalizer.cs
@@ -1,0 +1,17 @@
+#nullable enable
+
+namespace Microsoft.ApplicationInsights.Kubernetes.ContainerIdProviders;
+
+/// <summary>
+/// A service to normalize container id.
+/// </summary>
+internal interface IContainerIdNormalizer
+{
+    /// <summary>
+    /// Tries to normalize container id.
+    /// </summary>
+    /// <param name="input">The container id.</param>
+    /// <param name="normalized">The normalized container id.</param>
+    /// <returns>True when normalized. False otherwise.</returns>
+    bool TryNormalize(string input, out string? normalized);
+}

--- a/src/ApplicationInsights.Kubernetes/Extensions/KubernetesServiceCollectionBuilder.cs
+++ b/src/ApplicationInsights.Kubernetes/Extensions/KubernetesServiceCollectionBuilder.cs
@@ -106,6 +106,8 @@ namespace Microsoft.Extensions.DependencyInjection
                 _logger.LogError("Unsupported OS.");
             }
 
+            serviceCollection.TryAddSingleton<IContainerIdNormalizer, ContainerIdNormalizer>();
+
             // Notes: pay attention to the order. Injecting uses the order of registering in this case.
             // For backward compatibility, $APPINSIGHTS_KUBERNETES_POD_NAME has been agreed upon to allow customize pod name with downward API.
             serviceCollection.TryAddEnumerable(ServiceDescriptor.Singleton<IPodNameProvider, UserSetPodNameProvider>());

--- a/src/ApplicationInsights.Kubernetes/K8sHttpClient/KubeHttpClientSettingsProvider.cs
+++ b/src/ApplicationInsights.Kubernetes/K8sHttpClient/KubeHttpClientSettingsProvider.cs
@@ -15,19 +15,20 @@ namespace Microsoft.ApplicationInsights.Kubernetes
         private readonly string _certFilePath;
         private readonly string _tokenFilePath;
 
-        public KubeHttpClientSettingsProvider(IEnumerable<IContainerIdProvider> containerIdProviders)
-            : this(containerIdProviders, kubernetesServiceHost: null)
+        public KubeHttpClientSettingsProvider(IEnumerable<IContainerIdProvider> containerIdProviders, IContainerIdNormalizer containerIdNormalizer)
+            : this(containerIdProviders, containerIdNormalizer, kubernetesServiceHost: null)
         {
         }
 
         public KubeHttpClientSettingsProvider(
             IEnumerable<IContainerIdProvider> containerIdProviders,
+            IContainerIdNormalizer containerIdNormalizer,
             string pathToToken = @"/var/run/secrets/kubernetes.io/serviceaccount/token",
             string pathToCert = @"/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
             string pathToNamespace = @"/var/run/secrets/kubernetes.io/serviceaccount/namespace",
             string? kubernetesServiceHost = null,
             string? kubernetesServicePort = null)
-            : base(kubernetesServiceHost, kubernetesServicePort, containerIdProviders)
+            : base(kubernetesServiceHost, kubernetesServicePort, containerIdProviders, containerIdNormalizer)
         {
             _tokenFilePath = Arguments.IsNotNullOrEmpty(pathToToken, nameof(pathToToken));
             _certFilePath = Arguments.IsNotNullOrEmpty(pathToCert, nameof(pathToCert));

--- a/src/ApplicationInsights.Kubernetes/K8sHttpClient/KubeHttpSettingsWinContainerProvider.cs
+++ b/src/ApplicationInsights.Kubernetes/K8sHttpClient/KubeHttpSettingsWinContainerProvider.cs
@@ -13,13 +13,14 @@ namespace Microsoft.ApplicationInsights.Kubernetes
 
         public KubeHttpSettingsWinContainerProvider(
             IEnumerable<IContainerIdProvider> containerIdProviders,
+            IContainerIdNormalizer containerIdNormalizer,
             string serviceAccountFolder = @"C:\var\run\secrets\kubernetes.io\serviceaccount",
             string tokenFileName = "token",
             string certFileName = "ca.crt",
             string namespaceFileName = "namespace",
             string kubernetesServiceHost = null,
             string kubernetesServicePort = null)
-            : base(kubernetesServiceHost, kubernetesServicePort, containerIdProviders)
+            : base(kubernetesServiceHost, kubernetesServicePort, containerIdProviders, containerIdNormalizer)
         {
             // Container id won't be fetched for windows container.
             DirectoryInfo serviceAccountDirectory =

--- a/tests/UnitTests/ContainerIdNormalizerTests.cs
+++ b/tests/UnitTests/ContainerIdNormalizerTests.cs
@@ -25,16 +25,6 @@ public class ContainerIdNormalizerTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact]
-    public void TryGetNormalizedShouldHandleStringEmpty()
-    {
-        ContainerIdNormalizer target = new ContainerIdNormalizer();
-        bool result = target.TryNormalize(string.Empty, out string actual);
-
-        Assert.True(result);
-        Assert.Equal(string.Empty, actual);
-    }
-
     [Theory]
     // Input has no container id
     [InlineData("Input has no container id")]
@@ -50,7 +40,17 @@ public class ContainerIdNormalizerTests
         bool result = target.TryNormalize(input, out string actual);
 
         Assert.False(result);
-        Assert.Equal(null, actual);
+        Assert.Null(actual);
+    }
+
+    [Fact]
+    public void TryGetNormalizedShouldHandleStringEmpty()
+    {
+        ContainerIdNormalizer target = new ContainerIdNormalizer();
+        bool result = target.TryNormalize(string.Empty, out string actual);
+
+        Assert.True(result);
+        Assert.Equal(string.Empty, actual);
     }
 
     [Fact]

--- a/tests/UnitTests/ContainerIdNormalizerTests.cs
+++ b/tests/UnitTests/ContainerIdNormalizerTests.cs
@@ -1,0 +1,65 @@
+using System;
+using Xunit;
+
+namespace Microsoft.ApplicationInsights.Kubernetes.ContainerIdProviders.Tests;
+
+public class ContainerIdNormalizerTests
+{
+    [Theory]
+    // With prefix and suffix:
+    [InlineData(@"cri-containerd-5146b2bcd77ab4f2624bc1fbd98cf9751741344a80b043dbd77a4e847bff4f06.scope", "5146b2bcd77ab4f2624bc1fbd98cf9751741344a80b043dbd77a4e847bff4f06")]
+    // With prefix only:
+    [InlineData(@"docker://5146b2bcd77ab4f2624bc1fbd98cf9751741344a80b043dbd77a4e847bff4f06", "5146b2bcd77ab4f2624bc1fbd98cf9751741344a80b043dbd77a4e847bff4f06")]
+    // With suffix only:
+    [InlineData(@"5146b2bcd77ab4f2624bc1fbd98cf9751741344a80b043dbd77a4e847bff4f06-scope", "5146b2bcd77ab4f2624bc1fbd98cf9751741344a80b043dbd77a4e847bff4f06")]
+    // Same as normalized:
+    [InlineData(@"5146b2bcd77ab4f2624bc1fbd98cf9751741344a80b043dbd77a4e847bff4f06", "5146b2bcd77ab4f2624bc1fbd98cf9751741344a80b043dbd77a4e847bff4f06")]
+    // Longer than 64 digits - notes: so that the match regex is simplified.
+    [InlineData(@"5146b2bcd77ab4f2624bc1fbd98cf9751741344a80b043dbd77a4e847bff4f06a", "5146b2bcd77ab4f2624bc1fbd98cf9751741344a80b043dbd77a4e847bff4f06")]
+    public void TryGetNormalizedShouldNormalizeContainerIds(string input, string expected)
+    {
+        ContainerIdNormalizer target = new ContainerIdNormalizer();
+        bool result = target.TryNormalize(input, out string actual);
+
+        Assert.True(result);
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void TryGetNormalizedShouldHandleStringEmpty()
+    {
+        ContainerIdNormalizer target = new ContainerIdNormalizer();
+        bool result = target.TryNormalize(string.Empty, out string actual);
+
+        Assert.True(result);
+        Assert.Equal(string.Empty, actual);
+    }
+
+    [Theory]
+    // Input has no container id
+    [InlineData("Input has no container id")]
+    // Short guid is not accepted
+    [InlineData("f78375b1c487")]
+    // Shorter than 64 digits
+    [InlineData("5146b2bcd77ab4f2624bc1fbd98cf9751741344a80b043dbd77a4e847bff4f0")]
+    // Not a valid guid with character of z
+    [InlineData("5146b2bcd77ab4f2624bc1fbd98cf9751741344a80b043dbd77a4e847bff4f0z")]
+    public void TryGetNormalizedShouldNotAcceptInvalidContainerIds(string input)
+    {
+        ContainerIdNormalizer target = new ContainerIdNormalizer();
+        bool result = target.TryNormalize(input, out string actual);
+
+        Assert.False(result);
+        Assert.Equal(null, actual);
+    }
+
+    [Fact]
+    public void TryGetNormalizedShouldDoesNotAcceptNull()
+    {
+        ContainerIdNormalizer target = new ContainerIdNormalizer();
+        Assert.Throws<ArgumentNullException>(() =>
+        {
+            _ = target.TryNormalize(null, out string actual);
+        });
+    }
+}

--- a/tests/UnitTests/KuteHttpClientSettingsProviderTests.cs
+++ b/tests/UnitTests/KuteHttpClientSettingsProviderTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.ApplicationInsights.Kubernetes.ContainerIdProviders;
+using Moq;
 using Xunit;
 
 namespace Microsoft.ApplicationInsights.Kubernetes
@@ -11,8 +12,10 @@ namespace Microsoft.ApplicationInsights.Kubernetes
         [Fact(DisplayName = "Base address is formed by constructor")]
         public void BaseAddressShouldBeFormed()
         {
+            IContainerIdNormalizer containerIdNormalizer = new ContainerIdNormalizer();
             IKubeHttpClientSettingsProvider target = new KubeHttpClientSettingsProvider(
                 GetConatinerIdProviders(),
+                containerIdNormalizer,
                 pathToNamespace: "namespace",
                 kubernetesServiceHost: "127.0.0.1",
                 kubernetesServicePort: "8001");
@@ -25,8 +28,10 @@ namespace Microsoft.ApplicationInsights.Kubernetes
         [Fact(DisplayName = "Base address is formed by constructor of windows kube settings provider")]
         public void BaseAddressShouldBeFormedWin()
         {
+            IContainerIdNormalizer containerIdNormalizer = new ContainerIdNormalizer();
             IKubeHttpClientSettingsProvider target = new KubeHttpSettingsWinContainerProvider(
                 GetConatinerIdProviders(),
+                containerIdNormalizer,
                 serviceAccountFolder: ".",
                 namespaceFileName: "namespace",
                 kubernetesServiceHost: "127.0.0.1",
@@ -39,8 +44,10 @@ namespace Microsoft.ApplicationInsights.Kubernetes
         [Fact(DisplayName = "Container id is set to string.Empty for windows container settings")]
         public void ContainerIdIsAlwaysNullForWinSettings()
         {
+            IContainerIdNormalizer containerIdNormalizer = new ContainerIdNormalizer();
             IKubeHttpClientSettingsProvider target = new KubeHttpSettingsWinContainerProvider(
                 GetConatinerIdProviders(),
+                containerIdNormalizer,
                 serviceAccountFolder: ".",
                 namespaceFileName: "namespace",
                 kubernetesServiceHost: "127.0.0.1",
@@ -52,8 +59,10 @@ namespace Microsoft.ApplicationInsights.Kubernetes
 
         public void TokenShoudBeFetched()
         {
+            IContainerIdNormalizer containerIdNormalizer = new ContainerIdNormalizer();
             IKubeHttpClientSettingsProvider target = new KubeHttpClientSettingsProvider(
                 GetConatinerIdProviders(),
+                containerIdNormalizer,
                 pathToNamespace: "namespace",
                 pathToToken: "token",
                 kubernetesServiceHost: "127.0.0.1",
@@ -64,8 +73,10 @@ namespace Microsoft.ApplicationInsights.Kubernetes
         [Fact(DisplayName = "Token can be fetched by windows settings provider")]
         public void TokenShouldBeFetchedForWin()
         {
+            IContainerIdNormalizer containerIdNormalizer = new ContainerIdNormalizer();
             IKubeHttpClientSettingsProvider target = new KubeHttpSettingsWinContainerProvider(
                 GetConatinerIdProviders(),
+                containerIdNormalizer,
                 serviceAccountFolder: ".",
                 namespaceFileName: "namespace",
                 tokenFileName:"token",
@@ -78,8 +89,10 @@ namespace Microsoft.ApplicationInsights.Kubernetes
         [Fact(DisplayName = "Return true when certificate chain is valid")]
         public void TrueWhenValidCertificate()
         {
+            IContainerIdNormalizer containerIdNormalizer = new ContainerIdNormalizer();
             KubeHttpClientSettingsProvider target = new KubeHttpClientSettingsProvider(
                 GetConatinerIdProviders(),
+                containerIdNormalizer,
                 pathToNamespace: "namespace",
                 kubernetesServiceHost: "127.0.0.1",
                 kubernetesServicePort: "8001");
@@ -95,8 +108,10 @@ namespace Microsoft.ApplicationInsights.Kubernetes
         [Fact(DisplayName = "Return false when certificate chain is invalid")]
         public void FalseWhenInvalidCertificate()
         {
+            IContainerIdNormalizer containerIdNormalizer = new ContainerIdNormalizer();
             KubeHttpClientSettingsProvider target = new KubeHttpClientSettingsProvider(
                 GetConatinerIdProviders(),
+                containerIdNormalizer,
                 pathToNamespace: "namespace",
                 kubernetesServiceHost: "127.0.0.1",
                 kubernetesServicePort: "8001");
@@ -112,8 +127,10 @@ namespace Microsoft.ApplicationInsights.Kubernetes
         [Fact(DisplayName = "Return false when certificate out of date")]
         public void FalseWhenOutOfDateCertificate()
         {
+            IContainerIdNormalizer containerIdNormalizer = new ContainerIdNormalizer();
             KubeHttpClientSettingsProvider target = new KubeHttpClientSettingsProvider(
                 GetConatinerIdProviders(),
+                containerIdNormalizer,
                 pathToNamespace: "namespace",
                 kubernetesServiceHost: "127.0.0.1",
                 kubernetesServicePort: "8001");


### PR DESCRIPTION
Address #292 

To address the potential mismatch that could happen for all container id providers, I introduced a new interface - `IContainerIdNormalizer` to normalize all formats of container ids to the GUID/UUID only. In the example of the issue, it would be `5146b2bcd77ab4f2624bc1fbd98cf9751741344a80b043dbd77a4e847bff4f06` to match the expectation.

The normalization always happens after the container id is fetched.