### PR TITLE
Using background service to fetch k8s cluster info

### DIFF
--- a/dev/F5WebApi/appsettings.json
+++ b/dev/F5WebApi/appsettings.json
@@ -5,5 +5,8 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "AppInsightsForKubernetes": {
+    "ClusterInfoRefreshInterval": "00:01:00"
+  }
 }

--- a/src/ApplicationInsights.Kubernetes/ApplicationInsights.Kubernetes.csproj
+++ b/src/ApplicationInsights.Kubernetes/ApplicationInsights.Kubernetes.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="KubernetesClient" Version="6.0.26" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.21.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.DiagnosticAdapter" Version="3.1.27" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />

--- a/src/ApplicationInsights.Kubernetes/Containers/ContainerStatusManager.cs
+++ b/src/ApplicationInsights.Kubernetes/Containers/ContainerStatusManager.cs
@@ -46,10 +46,14 @@ internal class ContainerStatusManager : IContainerStatusManager
         //Known container id
         if (!string.IsNullOrEmpty(containerId))
         {
+            // There is a container id, check the status
             if (_podInfoManager.TryGetContainerStatus(myPod, containerId, out V1ContainerStatus? foundContainerStatus))
             {
+                // Found status
                 return foundContainerStatus;
             }
+            // Container status not ready yet.
+            return null;
         }
 
         // If there's no container id provided by the container id holder, at this moment, try backfill

--- a/src/ApplicationInsights.Kubernetes/Containers/ContainerStatusManager.cs
+++ b/src/ApplicationInsights.Kubernetes/Containers/ContainerStatusManager.cs
@@ -1,9 +1,12 @@
+using System;
+using System.Net;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using k8s.Models;
 using Microsoft.ApplicationInsights.Kubernetes.Debugging;
 using Microsoft.ApplicationInsights.Kubernetes.PodInfoProviders;
+using Microsoft.Rest;
 
 namespace Microsoft.ApplicationInsights.Kubernetes.Containers;
 
@@ -77,6 +80,34 @@ internal class ContainerStatusManager : IContainerStatusManager
     {
         _logger.LogTrace($"Container status object: {containerStatus}, isReady: {containerStatus?.Ready}");
         return containerStatus is not null && containerStatus.Ready;
+    }
+
+    public async Task<V1ContainerStatus?> WaitContainerReadyAsync(CancellationToken cancellationToken)
+    {
+        while(true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            try
+            {
+                if (await IsContainerReadyAsync(cancellationToken).ConfigureAwait(false))
+                {
+                    return await GetMyContainerStatusAsync(cancellationToken).ConfigureAwait(false);
+                }
+            }
+            catch (Exception ex) when (ex is not HttpOperationException || (ex is HttpOperationException operationException && operationException.Response.StatusCode != HttpStatusCode.Forbidden))
+            {
+                _logger.LogWarning($"Query exception while trying to get container info: {ex.Message}");
+                _logger.LogDebug(ex.ToString());
+            }
+
+            // The time to get the container ready depends on how much time will a container to be initialized.
+            // When there is readiness probe, the pod info will not be available until the initial delay of it is elapsed.
+            // When there is no readiness probe, the minimum seems about 1000ms. 
+            // Try invoke a probe on readiness every 500ms until the container is ready
+            // Or it will timeout per the timeout settings.
+            await Task.Delay(TimeSpan.FromMilliseconds(500), cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
     }
 }
 

--- a/src/ApplicationInsights.Kubernetes/Containers/IContainerStatusManager.cs
+++ b/src/ApplicationInsights.Kubernetes/Containers/IContainerStatusManager.cs
@@ -8,4 +8,14 @@ internal interface IContainerStatusManager
 {
     Task<V1ContainerStatus?> GetMyContainerStatusAsync(CancellationToken cancellationToken);
     Task<bool> IsContainerReadyAsync(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Waits until the container is ready.
+    /// Refer document @ https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase for the Pod's lifecycle.
+    /// </summary>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>
+    /// Returns the container status.
+    /// </returns>
+    Task<V1ContainerStatus?> WaitContainerReadyAsync(CancellationToken cancellationToken);
 }

--- a/src/ApplicationInsights.Kubernetes/Extensions/AppInsightsForKubernetesOptions.cs
+++ b/src/ApplicationInsights.Kubernetes/Extensions/AppInsightsForKubernetesOptions.cs
@@ -1,12 +1,10 @@
 using System;
-using Newtonsoft.Json;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
     /// <summary>
     /// Object model of configuration for Application Insights for Kubernetes.
     /// </summary>
-    [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     public class AppInsightsForKubernetesOptions
     {
         /// <summary>
@@ -17,7 +15,6 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <summary>
         /// Maximum time to wait for spinning up the container.
         /// </summary>
-        [JsonProperty("InitializationTimeout")]
         public TimeSpan InitializationTimeout { get; set; } = TimeSpan.FromMinutes(2);
 
         /// <summary>
@@ -25,5 +22,12 @@ namespace Microsoft.Extensions.DependencyInjection
         /// telemetry keys.
         /// </summary>
         public Func<string, string>? TelemetryKeyProcessor { get; set; }
+
+        /// <summary>
+        /// Get or sets how frequent to refresh the cluster info.
+        /// For example: 00:10:00 for 10 minutes.
+        /// The default value is 10 minutes.
+        /// </summary>
+        public TimeSpan ClusterInfoRefreshInterval { get; set; } = TimeSpan.FromMinutes(10);
     }
 }

--- a/src/ApplicationInsights.Kubernetes/Extensions/KubernetesServiceCollectionBuilder.cs
+++ b/src/ApplicationInsights.Kubernetes/Extensions/KubernetesServiceCollectionBuilder.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.InteropServices;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.ApplicationInsights.Kubernetes;
@@ -135,7 +135,7 @@ namespace Microsoft.Extensions.DependencyInjection
         protected virtual void RegisterK8sEnvironmentFactory(IServiceCollection serviceCollection)
         {
             serviceCollection.TryAddScoped<IK8sEnvironmentFactory, K8sEnvironmentFactory>();
-            serviceCollection.TryAddSingleton<K8sEnvironmentHolder>(_ => K8sEnvironmentHolder.Instance);
+            serviceCollection.TryAddSingleton<IK8sEnvironmentHolder>(_ => K8sEnvironmentHolder.Instance);
             serviceCollection.AddHostedService<K8sInfoBackgroundService>();
         }
     }

--- a/src/ApplicationInsights.Kubernetes/Extensions/KubernetesServiceCollectionBuilder.cs
+++ b/src/ApplicationInsights.Kubernetes/Extensions/KubernetesServiceCollectionBuilder.cs
@@ -133,6 +133,10 @@ namespace Microsoft.Extensions.DependencyInjection
         /// Registers K8s environment factory.
         /// </summary>
         protected virtual void RegisterK8sEnvironmentFactory(IServiceCollection serviceCollection)
-            => serviceCollection.AddSingleton<IK8sEnvironmentFactory, K8sEnvironmentFactory>();
+        {
+            serviceCollection.TryAddScoped<IK8sEnvironmentFactory, K8sEnvironmentFactory>();
+            serviceCollection.TryAddSingleton<K8sEnvironmentHolder>(_ => K8sEnvironmentHolder.Instance);
+            serviceCollection.AddHostedService<K8sInfoBackgroundService>();
+        }
     }
 }

--- a/src/ApplicationInsights.Kubernetes/IK8sEnvironmentHolder.cs
+++ b/src/ApplicationInsights.Kubernetes/IK8sEnvironmentHolder.cs
@@ -1,0 +1,7 @@
+namespace Microsoft.ApplicationInsights.Kubernetes
+{
+    internal interface IK8sEnvironmentHolder
+    {
+        IK8sEnvironment? K8sEnvironment { get; internal set; }
+    }
+}

--- a/src/ApplicationInsights.Kubernetes/Interfaces/IK8sEnvironmentFactory.cs
+++ b/src/ApplicationInsights.Kubernetes/Interfaces/IK8sEnvironmentFactory.cs
@@ -1,11 +1,14 @@
-﻿using System;
-using System.Threading;
+﻿using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.ApplicationInsights.Kubernetes
 {
     internal interface IK8sEnvironmentFactory
     {
-        Task<IK8sEnvironment?> CreateAsync(DateTime timeoutAt, CancellationToken cancellationToken);
+        /// <summary>
+        /// Creates an instance of an IK8sEnvironment.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        Task<IK8sEnvironment?> CreateAsync(CancellationToken cancellationToken);
     }
 }

--- a/src/ApplicationInsights.Kubernetes/K8sEnvironmentFactory.cs
+++ b/src/ApplicationInsights.Kubernetes/K8sEnvironmentFactory.cs
@@ -10,7 +10,6 @@ using Microsoft.ApplicationInsights.Kubernetes.Containers;
 using Microsoft.ApplicationInsights.Kubernetes.Debugging;
 using Microsoft.ApplicationInsights.Kubernetes.PodInfoProviders;
 using Microsoft.Rest;
-using static Microsoft.ApplicationInsights.Kubernetes.StringUtils;
 
 namespace Microsoft.ApplicationInsights.Kubernetes
 {
@@ -43,10 +42,10 @@ namespace Microsoft.ApplicationInsights.Kubernetes
             try
             {
                 // When my pod become available and it's status become ready, we recognize the container is ready.
+                V1Pod myPod = await _podInfoManager.WaitUntilMyPodReadyAsync(cancellationToken).ConfigureAwait(false);
 
-                // TODO: See if there's better way to fetch pod
-                V1Pod myPod = await SpinWaitUntilGetPodAsync(cancellationToken).ConfigureAwait(false);
-                V1ContainerStatus? containerStatus = await SpinWaitContainerReadyAsync(cancellationToken).ConfigureAwait(false);
+                // Wait until the container is ready.
+                V1ContainerStatus? containerStatus = await _containerStatusManager.WaitContainerReadyAsync(cancellationToken).ConfigureAwait(false);
 
                 // Fetch replica set info
                 IEnumerable<V1ReplicaSet> allReplicaSet = await _k8sClient.GetReplicaSetsAsync(cancellationToken).ConfigureAwait(false);
@@ -75,77 +74,6 @@ namespace Microsoft.ApplicationInsights.Kubernetes
                 return null;
             }
 #pragma warning restore CA1031 // Do not catch general exception types
-        }
-
-        private async Task<V1Pod> SpinWaitUntilGetPodAsync(CancellationToken cancellationToken)
-        {
-            Stopwatch stopwatch = new Stopwatch();
-            stopwatch.Start();
-            V1Pod? myPod = null;
-            do
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                try
-                {
-                    myPod = await _podInfoManager.GetMyPodAsync(cancellationToken).ConfigureAwait(false);
-                }
-                catch (Exception ex) when (ex is not HttpOperationException || (ex is HttpOperationException operationException && operationException.Response.StatusCode != HttpStatusCode.Forbidden))
-                {
-                    _logger.LogWarning($"Query exception while trying to get pod info: {ex.Message}");
-                    _logger.LogDebug(ex.ToString());
-                }
-
-                stopwatch.Stop();
-                if (myPod is not null)
-                {
-                    _logger.LogDebug(Invariant($"K8s pod info available in: {stopwatch.ElapsedMilliseconds} ms."));
-                    return myPod;
-                }
-
-                // The time to get the container ready depends on how much time will a container to be initialized.
-                // When there is readiness probe, the pod info will not be available until the initial delay of it is elapsed.
-                // When there is no readiness probe, the minimum seems about 1000ms. 
-                // Try invoke a probe on readiness every 500ms until the container is ready
-                // Or it will timeout per the timeout settings.
-                await Task.Delay(TimeSpan.FromMilliseconds(500), cancellationToken: cancellationToken).ConfigureAwait(false);
-            } while (true);
-        }
-
-        /// <summary>
-        /// Waits until the container is ready.
-        /// Refer document @ https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase for the Pod's lifecycle.
-        /// </summary>
-        /// <param name="cancellationToken">The cancellation token.</param>
-        /// <returns>
-        /// Returns the pod with refreshed info on it.
-        /// </returns>
-        private async Task<V1ContainerStatus?> SpinWaitContainerReadyAsync(CancellationToken cancellationToken)
-        {
-            do
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                try
-                {
-                    if (await _containerStatusManager.IsContainerReadyAsync(cancellationToken).ConfigureAwait(false))
-                    {
-                        return await _containerStatusManager.GetMyContainerStatusAsync(cancellationToken).ConfigureAwait(false);
-                    }
-                }
-                catch (Exception ex) when (ex is not HttpOperationException || (ex is HttpOperationException operationException && operationException.Response.StatusCode != HttpStatusCode.Forbidden))
-                {
-                    _logger.LogWarning($"Query exception while trying to get container info: {ex.Message}");
-                    _logger.LogDebug(ex.ToString());
-                }
-
-                // The time to get the container ready depends on how much time will a container to be initialized.
-                // When there is readiness probe, the pod info will not be available until the initial delay of it is elapsed.
-                // When there is no readiness probe, the minimum seems about 1000ms. 
-                // Try invoke a probe on readiness every 500ms until the container is ready
-                // Or it will timeout per the timeout settings.
-                await Task.Delay(TimeSpan.FromMilliseconds(500), cancellationToken: cancellationToken).ConfigureAwait(false);
-            } while (true);
         }
 
         private void HandleUnauthorizedAccess(HttpOperationException exception)

--- a/src/ApplicationInsights.Kubernetes/K8sEnvironmentFactory.cs
+++ b/src/ApplicationInsights.Kubernetes/K8sEnvironmentFactory.cs
@@ -122,9 +122,6 @@ namespace Microsoft.ApplicationInsights.Kubernetes
         /// </returns>
         private async Task<V1ContainerStatus?> SpinWaitContainerReadyAsync(CancellationToken cancellationToken)
         {
-            Stopwatch stopwatch = new Stopwatch();
-            stopwatch.Start();
-
             do
             {
                 cancellationToken.ThrowIfCancellationRequested();

--- a/src/ApplicationInsights.Kubernetes/K8sEnvironmentFactory.cs
+++ b/src/ApplicationInsights.Kubernetes/K8sEnvironmentFactory.cs
@@ -108,7 +108,7 @@ namespace Microsoft.ApplicationInsights.Kubernetes
                 // When there is no readiness probe, the minimum seems about 1000ms. 
                 // Try invoke a probe on readiness every 500ms until the container is ready
                 // Or it will timeout per the timeout settings.
-                await Task.Delay(500).ConfigureAwait(false);
+                await Task.Delay(TimeSpan.FromMilliseconds(500), cancellationToken: cancellationToken).ConfigureAwait(false);
             } while (true);
         }
 
@@ -131,7 +131,6 @@ namespace Microsoft.ApplicationInsights.Kubernetes
 
                 try
                 {
-
                     if (await _containerStatusManager.IsContainerReadyAsync(cancellationToken).ConfigureAwait(false))
                     {
                         return await _containerStatusManager.GetMyContainerStatusAsync(cancellationToken).ConfigureAwait(false);
@@ -148,7 +147,7 @@ namespace Microsoft.ApplicationInsights.Kubernetes
                 // When there is no readiness probe, the minimum seems about 1000ms. 
                 // Try invoke a probe on readiness every 500ms until the container is ready
                 // Or it will timeout per the timeout settings.
-                await Task.Delay(500).ConfigureAwait(false);
+                await Task.Delay(TimeSpan.FromMilliseconds(500), cancellationToken: cancellationToken).ConfigureAwait(false);
             } while (true);
         }
 

--- a/src/ApplicationInsights.Kubernetes/K8sEnvironmentHolder.cs
+++ b/src/ApplicationInsights.Kubernetes/K8sEnvironmentHolder.cs
@@ -5,11 +5,8 @@ namespace Microsoft.ApplicationInsights.Kubernetes;
 /// </summary>
 internal sealed class K8sEnvironmentHolder
 {
-    private K8sEnvironmentHolder()
-    {
-        IsQueryTimeout = false;
-    }
-    
+    private K8sEnvironmentHolder() { }
+
     public static K8sEnvironmentHolder Instance { get; } = new K8sEnvironmentHolder();
 
     /// <summary>
@@ -17,9 +14,4 @@ internal sealed class K8sEnvironmentHolder
     /// Returns null when the environment is info is not ready for consuming.
     /// </summary>
     public IK8sEnvironment? K8sEnvironment { get; internal set; }
-
-    /// <summary>
-    /// Gets whether the query for K8s cluster info timed out or not.
-    /// </summary>
-    public bool IsQueryTimeout { get; internal set; }
 }

--- a/src/ApplicationInsights.Kubernetes/K8sEnvironmentHolder.cs
+++ b/src/ApplicationInsights.Kubernetes/K8sEnvironmentHolder.cs
@@ -3,8 +3,10 @@ namespace Microsoft.ApplicationInsights.Kubernetes;
 /// <summary>
 /// Provides a single point of access for K8sEnvironment object.
 /// </summary>
-internal sealed class K8sEnvironmentHolder
+internal sealed class K8sEnvironmentHolder : IK8sEnvironmentHolder
 {
+    private volatile IK8sEnvironment? _k8SEnvironment;
+
     private K8sEnvironmentHolder() { }
 
     public static K8sEnvironmentHolder Instance { get; } = new K8sEnvironmentHolder();
@@ -13,5 +15,15 @@ internal sealed class K8sEnvironmentHolder
     /// Gets or sets the kubernetes environment object.
     /// Returns null when the environment is info is not ready for consuming.
     /// </summary>
-    public IK8sEnvironment? K8sEnvironment { get; internal set; }
+    public IK8sEnvironment? K8sEnvironment
+    {
+        get
+        {
+            return _k8SEnvironment;
+        }
+        set
+        {
+            _k8SEnvironment = value;
+        }
+    }
 }

--- a/src/ApplicationInsights.Kubernetes/K8sEnvironmentHolder.cs
+++ b/src/ApplicationInsights.Kubernetes/K8sEnvironmentHolder.cs
@@ -1,0 +1,25 @@
+namespace Microsoft.ApplicationInsights.Kubernetes;
+
+/// <summary>
+/// Provides a single point of access for K8sEnvironment object.
+/// </summary>
+internal sealed class K8sEnvironmentHolder
+{
+    private K8sEnvironmentHolder()
+    {
+        IsQueryTimeout = false;
+    }
+    
+    public static K8sEnvironmentHolder Instance { get; } = new K8sEnvironmentHolder();
+
+    /// <summary>
+    /// Gets or sets the kubernetes environment object.
+    /// Returns null when the environment is info is not ready for consuming.
+    /// </summary>
+    public IK8sEnvironment? K8sEnvironment { get; internal set; }
+
+    /// <summary>
+    /// Gets whether the query for K8s cluster info timed out or not.
+    /// </summary>
+    public bool IsQueryTimeout { get; internal set; }
+}

--- a/src/ApplicationInsights.Kubernetes/K8sInfoBackgroundService.cs
+++ b/src/ApplicationInsights.Kubernetes/K8sInfoBackgroundService.cs
@@ -33,8 +33,8 @@ internal class K8sInfoBackgroundService : BackgroundService
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         TimeSpan interval = _options.ClusterInfoRefreshInterval;
-        
-        while (true)
+
+        while (!stoppingToken.IsCancellationRequested)
         {
             try
             {

--- a/src/ApplicationInsights.Kubernetes/K8sInfoBackgroundService.cs
+++ b/src/ApplicationInsights.Kubernetes/K8sInfoBackgroundService.cs
@@ -15,14 +15,14 @@ internal class K8sInfoBackgroundService : BackgroundService
 {
     private readonly ApplicationInsightsKubernetesDiagnosticSource _logger = ApplicationInsightsKubernetesDiagnosticSource.Instance;
     private readonly IServiceProvider _serviceProvider;
-    private readonly K8sEnvironmentHolder _k8SEnvironmentHolder;
+    private readonly IK8sEnvironmentHolder _k8SEnvironmentHolder;
     private readonly AppInsightsForKubernetesOptions _options;
 
     // Notice: This is a background service, the service lifetime will be singleton.
     // Do NOT inject services in scope of Scoped or Transient. Use the injected service provider instead.
     public K8sInfoBackgroundService(
         IServiceProvider serviceProvider,
-        K8sEnvironmentHolder k8SEnvironmentHolder,
+        IK8sEnvironmentHolder k8SEnvironmentHolder,
         IOptions<AppInsightsForKubernetesOptions> options)
     {
         _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));

--- a/src/ApplicationInsights.Kubernetes/K8sInfoBackgroundService.cs
+++ b/src/ApplicationInsights.Kubernetes/K8sInfoBackgroundService.cs
@@ -42,6 +42,7 @@ internal class K8sInfoBackgroundService : BackgroundService
                 await UpdateK8sEnvironmentAsync(cancellationToken: stoppingToken).ConfigureAwait(false);
                 _logger.LogDebug($"Finished {nameof(UpdateK8sEnvironmentAsync)}, next iteration will happen at {DateTime.UtcNow.Add(interval)} (UTC) by interval settings of {interval}");
 
+                // TODO: Consider using PeriodicTimer than delay below when move to .NET 6 +
                 await Task.Delay(interval, cancellationToken: stoppingToken);
             }
 #pragma warning disable CA1031 // Do not catch general exception types

--- a/src/ApplicationInsights.Kubernetes/K8sInfoBackgroundService.cs
+++ b/src/ApplicationInsights.Kubernetes/K8sInfoBackgroundService.cs
@@ -40,7 +40,7 @@ internal class K8sInfoBackgroundService : BackgroundService
             {
                 _logger.LogDebug($"Starting {nameof(UpdateK8sEnvironmentAsync)}");
                 await UpdateK8sEnvironmentAsync(cancellationToken: stoppingToken).ConfigureAwait(false);
-                _logger.LogDebug($"Finished {nameof(UpdateK8sEnvironmentAsync)}, next iteration will happen at {DateTime.Now.Add(interval)} by interval settings of {interval}");
+                _logger.LogDebug($"Finished {nameof(UpdateK8sEnvironmentAsync)}, next iteration will happen at {DateTime.UtcNow.Add(interval)} (UTC) by interval settings of {interval}");
 
                 await Task.Delay(interval, cancellationToken: stoppingToken);
             }

--- a/src/ApplicationInsights.Kubernetes/K8sInfoBackgroundService.cs
+++ b/src/ApplicationInsights.Kubernetes/K8sInfoBackgroundService.cs
@@ -40,7 +40,7 @@ internal class K8sInfoBackgroundService : BackgroundService
             {
                 _logger.LogDebug($"Starting {nameof(UpdateK8sEnvironmentAsync)}");
                 await UpdateK8sEnvironmentAsync(cancellationToken: stoppingToken).ConfigureAwait(false);
-                _logger.LogDebug($"Finished {nameof(UpdateK8sEnvironmentAsync)}, delay for {interval}");
+                _logger.LogDebug($"Finished {nameof(UpdateK8sEnvironmentAsync)}, next iteration will happen at {DateTime.Now.Add(interval)} by interval settings of {interval}");
 
                 await Task.Delay(interval, cancellationToken: stoppingToken);
             }

--- a/src/ApplicationInsights.Kubernetes/K8sInfoBackgroundService.cs
+++ b/src/ApplicationInsights.Kubernetes/K8sInfoBackgroundService.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.ApplicationInsights.Kubernetes.Debugging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.ApplicationInsights.Kubernetes;
+
+/// <summary>
+/// A bootstrap service to keep updating K8s environment.
+/// </summary>
+internal class K8sInfoBackgroundService : BackgroundService
+{
+    private readonly ApplicationInsightsKubernetesDiagnosticSource _logger = ApplicationInsightsKubernetesDiagnosticSource.Instance;
+    private readonly IServiceProvider _serviceProvider;
+    private readonly K8sEnvironmentHolder _k8SEnvironmentHolder;
+    private readonly AppInsightsForKubernetesOptions _options;
+
+    public K8sInfoBackgroundService(
+        IServiceProvider serviceProvider,
+        K8sEnvironmentHolder k8SEnvironmentHolder,
+        IOptions<AppInsightsForKubernetesOptions> options)
+    {
+        _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+        _k8SEnvironmentHolder = k8SEnvironmentHolder ?? throw new ArgumentNullException(nameof(k8SEnvironmentHolder));
+        _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (true)
+        {
+            try
+            {
+                _logger.LogDebug($"Starting {nameof(UpdateK8sEnvironmentAsync)}");
+                await UpdateK8sEnvironmentAsync(stoppingToken).ConfigureAwait(false);
+                TimeSpan interval = _options.ClusterInfoRefreshInterval;
+                _logger.LogDebug($"Finished {nameof(UpdateK8sEnvironmentAsync)}, delay for {interval}");
+                await Task.Delay(interval);
+            }
+#pragma warning disable CA1031 // Do not catch general exception types
+            catch (Exception ex)
+            {
+                // In case of any unexpected exception, we shall log it than let it throw.
+                _logger.LogError("Unexpected error happened. Telemetry enhancement with Kubernetes info won't happen. Message: {0}", ex.Message);
+                _logger.LogTrace("Unexpected error happened. Telemetry enhancement with Kubernetes info won't happen. Details: {0}", ex.ToString());
+            }
+#pragma warning restore CA1031 // Do not catch general exception types
+        }
+    }
+
+    private async Task UpdateK8sEnvironmentAsync(CancellationToken cancellationToken)
+    {
+        await using (AsyncServiceScope scope = _serviceProvider.CreateAsyncScope())
+        {
+            // Get scoped service ready
+            IServiceProvider provider = scope.ServiceProvider;
+            IK8sEnvironmentFactory factory = provider.GetRequiredService<IK8sEnvironmentFactory>();
+
+            // Prepare cancellation token with timeout.
+            using CancellationTokenSource timeoutSource = new CancellationTokenSource(_options.InitializationTimeout);
+            CancellationToken timeoutToken = timeoutSource.Token;
+            
+            try
+            {
+                using (CancellationTokenSource linkedTokeSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutToken))
+                {
+
+                    IK8sEnvironment? environment = await factory.CreateAsync(cancellationToken: linkedTokeSource.Token).ConfigureAwait(false);
+                    _k8SEnvironmentHolder.K8sEnvironment = environment;
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                if (timeoutToken.IsCancellationRequested)
+                {
+                    _logger.LogWarning("Querying Kubernetes cluster info timed out.");
+                    _k8SEnvironmentHolder.K8sEnvironment = null;
+                    _k8SEnvironmentHolder.IsQueryTimeout = true;
+                }
+                else
+                {
+                    _logger.LogInformation("Operation cancelled.");
+                }
+            }
+        }
+    }
+}

--- a/src/ApplicationInsights.Kubernetes/Pods/IPodInfoManager.cs
+++ b/src/ApplicationInsights.Kubernetes/Pods/IPodInfoManager.cs
@@ -7,6 +7,11 @@ namespace Microsoft.ApplicationInsights.Kubernetes.PodInfoProviders;
 internal interface IPodInfoManager
 {
     /// <summary>
+    /// Waits until the pod is ready and then return it. Returns null when the cancellation token is requested.
+    /// </summary>
+    Task<V1Pod> WaitUntilMyPodReadyAsync(CancellationToken cancellationToken);
+
+    /// <summary>
     /// Tries to get the pod.
     /// </summary>
     /// <returns>Returns the K8s Pod entity when located. Otherwise, null.</returns>

--- a/src/ApplicationInsights.Kubernetes/TelemetryInitializers/KubernetesTelemetryInitializer.cs
+++ b/src/ApplicationInsights.Kubernetes/TelemetryInitializers/KubernetesTelemetryInitializer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.ApplicationInsights.Extensibility;
@@ -7,144 +7,141 @@ using Microsoft.ApplicationInsights.Kubernetes.Debugging;
 using Microsoft.ApplicationInsights.Kubernetes.Utilities;
 using static Microsoft.ApplicationInsights.Kubernetes.TelemetryProperty;
 
-namespace Microsoft.ApplicationInsights.Kubernetes
+namespace Microsoft.ApplicationInsights.Kubernetes;
+
+/// <summary>
+/// Telemetry Initializer for K8s Environment
+/// </summary>
+internal class KubernetesTelemetryInitializer : ITelemetryInitializer
 {
-    /// <summary>
-    /// Telemetry Initializer for K8s Environment
-    /// </summary>
-    internal class KubernetesTelemetryInitializer : ITelemetryInitializer
+    private static readonly ApplicationInsightsKubernetesDiagnosticSource _logger = ApplicationInsightsKubernetesDiagnosticSource.Instance;
+    private readonly SDKVersionUtils _sdkVersionUtils;
+    internal IK8sEnvironmentHolder K8SEnvironmentHolder { get; }
+    internal ITelemetryKeyCache TelemetryKeyCache { get; }
+
+    public KubernetesTelemetryInitializer(
+        IK8sEnvironmentHolder k8sEnvironmentHolder,
+        SDKVersionUtils sdkVersionUtils,
+        ITelemetryKeyCache telemetryKeyCache)
     {
-        private static readonly ApplicationInsightsKubernetesDiagnosticSource _logger = ApplicationInsightsKubernetesDiagnosticSource.Instance;
-        private readonly K8sEnvironmentHolder _k8SEnvironmentHolder;
-        private readonly SDKVersionUtils _sdkVersionUtils;
-        internal ITelemetryKeyCache TelemetryKeyCache { get; }
-        internal IK8sEnvironment? K8sEnvironment { get; private set; }
+        TelemetryKeyCache = telemetryKeyCache ?? throw new ArgumentNullException(nameof(telemetryKeyCache));
+        K8SEnvironmentHolder = k8sEnvironmentHolder ?? throw new ArgumentNullException(nameof(k8sEnvironmentHolder));
+        _sdkVersionUtils = sdkVersionUtils ?? throw new ArgumentNullException(nameof(sdkVersionUtils));
+    }
 
-        public KubernetesTelemetryInitializer(
-            K8sEnvironmentHolder k8SEnvironmentHolder,
-            SDKVersionUtils sdkVersionUtils,
-            ITelemetryKeyCache telemetryKeyCache)
+    public void Initialize(ITelemetry telemetry)
+    {
+        IK8sEnvironment? k8sEnv = K8SEnvironmentHolder.K8sEnvironment;
+
+        if (k8sEnv != null)
         {
-            K8sEnvironment = null;
-            TelemetryKeyCache = telemetryKeyCache ?? throw new ArgumentNullException(nameof(telemetryKeyCache));
-            _k8SEnvironmentHolder = k8SEnvironmentHolder ?? throw new ArgumentNullException(nameof(k8SEnvironmentHolder));
-            _sdkVersionUtils = sdkVersionUtils ?? throw new ArgumentNullException(nameof(sdkVersionUtils));
-        }
-
-        public void Initialize(ITelemetry telemetry)
-        {
-            IK8sEnvironment? k8sEnv = K8sEnvironment = _k8SEnvironmentHolder.K8sEnvironment;
-
-            if (k8sEnv != null)
+            _logger.LogTrace("Application Insights for Kubernetes telemetry initializer is invoked.", k8sEnv.PodName);
+            try
             {
-                _logger.LogTrace("Application Insights for Kubernetes telemetry initializer is invoked.", k8sEnv.PodName);
-                try
-                {
-                    InitializeTelemetry(telemetry, k8sEnv);
-                }
+                InitializeTelemetry(telemetry, k8sEnv);
+            }
 #pragma warning disable CA1031 // Do not catch general exception types
-                catch (Exception ex)
-                {
-                    _logger.LogError(ex.ToString());
-                }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex.ToString());
+            }
 #pragma warning restore CA1031 // Do not catch general exception types
+        }
+        else
+        {
+            _logger.LogTrace("Application Insights for Kubernetes telemetry initializer is used but the content has not ready yet.");
+        }
+
+        telemetry.Context.GetInternalContext().SdkVersion = _sdkVersionUtils.CurrentSDKVersion;
+    }
+
+    private void InitializeTelemetry(ITelemetry telemetry, IK8sEnvironment k8sEnv)
+    {
+        // Setting the container name to role name
+        if (string.IsNullOrEmpty(telemetry.Context.Cloud.RoleName))
+        {
+            telemetry.Context.Cloud.RoleName = k8sEnv.ContainerName;
+        }
+
+        if (telemetry is ISupportProperties propertySetter)
+        {
+            SetCustomDimensions(propertySetter, k8sEnv);
+        }
+        else
+        {
+            _logger.LogTrace("This telemetry object doesn't implement ISupportProperties.");
+        }
+        _logger.LogTrace("Finish telemetry initializer.");
+    }
+
+    private void SetCustomDimensions(ISupportProperties telemetry, IK8sEnvironment k8sEnvironment)
+    {
+        // Container 
+        SetCustomDimension(telemetry, Container.ID, k8sEnvironment.ContainerID, isValueOptional: true);
+        SetCustomDimension(telemetry, Container.Name, k8sEnvironment.ContainerName, isValueOptional: true);
+
+        // Pod
+        SetCustomDimension(telemetry, Pod.ID, k8sEnvironment.PodID);
+        SetCustomDimension(telemetry, Pod.Name, k8sEnvironment.PodName);
+        SetCustomDimension(telemetry, Pod.Labels, k8sEnvironment.PodLabels, isValueOptional: true);
+        SetCustomDimension(telemetry, Pod.Namespace, k8sEnvironment.PodNamespace, isValueOptional: true);
+
+        // Pod will have no replica name or deployment when deployed through other means. For example, as a daemonset.
+        // Replica Set
+        SetCustomDimension(telemetry, ReplicaSet.Name, k8sEnvironment.ReplicaSetName, isValueOptional: true);
+
+        // Deployment
+        SetCustomDimension(telemetry, Deployment.Name, k8sEnvironment.DeploymentName, isValueOptional: true);
+
+        // Node
+        SetCustomDimension(telemetry, Node.ID, k8sEnvironment.NodeUid, isValueOptional: true);
+        SetCustomDimension(telemetry, Node.Name, k8sEnvironment.NodeName, isValueOptional: true);
+    }
+
+    private void SetCustomDimension(ISupportProperties telemetry, string key, string? value, bool isValueOptional = false)
+    {
+        key = TelemetryKeyCache.GetProcessedKey(key);
+
+        if (telemetry == null)
+        {
+            _logger.LogError("telemetry object is null in telemetry initializer.");
+            return;
+        }
+
+        if (string.IsNullOrEmpty(key))
+        {
+            _logger.LogError("Key is required to set custom dimension.");
+            return;
+        }
+
+        if (string.IsNullOrEmpty(value))
+        {
+            if (isValueOptional)
+            {
+                _logger.LogTrace("Value is null or empty for key: {0}", key);
             }
             else
             {
-                _logger.LogTrace("Application Insights for Kubernetes telemetry initializer is used but the content has not ready yet.");
+                _logger.LogError("Value is required to set custom dimension. Key: {0}", key);
             }
-
-            telemetry.Context.GetInternalContext().SdkVersion = _sdkVersionUtils.CurrentSDKVersion;
+            return;
         }
 
-        private void InitializeTelemetry(ITelemetry telemetry, IK8sEnvironment k8sEnv)
+        if (!telemetry.Properties.ContainsKey(key))
         {
-            // Setting the container name to role name
-            if (string.IsNullOrEmpty(telemetry.Context.Cloud.RoleName))
+            telemetry.Properties.Add(key, value);
+        }
+        else
+        {
+            string existingValue = telemetry.Properties[key];
+            if (string.Equals(existingValue, value, System.StringComparison.OrdinalIgnoreCase))
             {
-                telemetry.Context.Cloud.RoleName = k8sEnv.ContainerName;
-            }
-
-            if (telemetry is ISupportProperties propertySetter)
-            {
-                SetCustomDimensions(propertySetter, k8sEnv);
+                _logger.LogTrace("The telemetry already contains the property of {0} with the same value of {1}.", key, existingValue);
             }
             else
             {
-                _logger.LogTrace("This telemetry object doesn't implement ISupportProperties.");
-            }
-            _logger.LogTrace("Finish telemetry initializer.");
-        }
-
-        private void SetCustomDimensions(ISupportProperties telemetry, IK8sEnvironment k8sEnvironment)
-        {
-            // Container 
-            SetCustomDimension(telemetry, Container.ID, k8sEnvironment.ContainerID, isValueOptional: true);
-            SetCustomDimension(telemetry, Container.Name, k8sEnvironment.ContainerName, isValueOptional: true);
-
-            // Pod
-            SetCustomDimension(telemetry, Pod.ID, k8sEnvironment.PodID);
-            SetCustomDimension(telemetry, Pod.Name, k8sEnvironment.PodName);
-            SetCustomDimension(telemetry, Pod.Labels, k8sEnvironment.PodLabels, isValueOptional: true);
-            SetCustomDimension(telemetry, Pod.Namespace, k8sEnvironment.PodNamespace, isValueOptional: true);
-
-            // Pod will have no replica name or deployment when deployed through other means. For example, as a daemonset.
-            // Replica Set
-            SetCustomDimension(telemetry, ReplicaSet.Name, k8sEnvironment.ReplicaSetName, isValueOptional: true);
-
-            // Deployment
-            SetCustomDimension(telemetry, Deployment.Name, k8sEnvironment.DeploymentName, isValueOptional: true);
-
-            // Node
-            SetCustomDimension(telemetry, Node.ID, k8sEnvironment.NodeUid, isValueOptional: true);
-            SetCustomDimension(telemetry, Node.Name, k8sEnvironment.NodeName, isValueOptional: true);
-        }
-
-        private void SetCustomDimension(ISupportProperties telemetry, string key, string? value, bool isValueOptional = false)
-        {
-            key = TelemetryKeyCache.GetProcessedKey(key);
-
-            if (telemetry == null)
-            {
-                _logger.LogError("telemetry object is null in telemetry initializer.");
-                return;
-            }
-
-            if (string.IsNullOrEmpty(key))
-            {
-                _logger.LogError("Key is required to set custom dimension.");
-                return;
-            }
-
-            if (string.IsNullOrEmpty(value))
-            {
-                if (isValueOptional)
-                {
-                    _logger.LogTrace("Value is null or empty for key: {0}", key);
-                }
-                else
-                {
-                    _logger.LogError("Value is required to set custom dimension. Key: {0}", key);
-                }
-                return;
-            }
-
-            if (!telemetry.Properties.ContainsKey(key))
-            {
-                telemetry.Properties.Add(key, value);
-            }
-            else
-            {
-                string existingValue = telemetry.Properties[key];
-                if (string.Equals(existingValue, value, System.StringComparison.OrdinalIgnoreCase))
-                {
-                    _logger.LogTrace("The telemetry already contains the property of {0} with the same value of {1}.", key, existingValue);
-                }
-                else
-                {
-                    telemetry.Properties[key] = value;
-                    _logger.LogDebug("The telemetry already contains the property of {0} with value {1}. The new value is: {2}", key, existingValue, value);
-                }
+                telemetry.Properties[key] = value;
+                _logger.LogDebug("The telemetry already contains the property of {0} with value {1}. The new value is: {2}", key, existingValue, value);
             }
         }
     }

--- a/src/ApplicationInsights.Kubernetes/TelemetryInitializers/KubernetesTelemetryInitializer.cs
+++ b/src/ApplicationInsights.Kubernetes/TelemetryInitializers/KubernetesTelemetryInitializer.cs
@@ -17,7 +17,6 @@ namespace Microsoft.ApplicationInsights.Kubernetes
         private static readonly ApplicationInsightsKubernetesDiagnosticSource _logger = ApplicationInsightsKubernetesDiagnosticSource.Instance;
         private readonly K8sEnvironmentHolder _k8SEnvironmentHolder;
         private readonly SDKVersionUtils _sdkVersionUtils;
-        private bool _isK8sQueryTimeoutReported = false;
         internal ITelemetryKeyCache TelemetryKeyCache { get; }
         internal IK8sEnvironment? K8sEnvironment { get; private set; }
 
@@ -53,12 +52,6 @@ namespace Microsoft.ApplicationInsights.Kubernetes
             else
             {
                 _logger.LogTrace("Application Insights for Kubernetes telemetry initializer is used but the content has not ready yet.");
-
-                if (_k8SEnvironmentHolder?.IsQueryTimeout == true && !_isK8sQueryTimeoutReported)
-                {
-                    _isK8sQueryTimeoutReported = true;
-                    _logger.LogError("Query Kubernetes Environment timeout.");
-                }
             }
 
             telemetry.Context.GetInternalContext().SdkVersion = _sdkVersionUtils.CurrentSDKVersion;

--- a/tests/UnitTests/K8sEnvironemntFactoryTests.cs
+++ b/tests/UnitTests/K8sEnvironemntFactoryTests.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using k8s.Models;
+using Microsoft.ApplicationInsights.Kubernetes.Containers;
+using Microsoft.ApplicationInsights.Kubernetes.PodInfoProviders;
+using Moq;
+using Xunit;
+
+namespace Microsoft.ApplicationInsights.Kubernetes
+{
+    public class K8sEnvironemntFactoryTests
+    {
+        [Fact]
+        public async Task ShouldTimeoutWaitingPodReady()
+        {
+            Mock<IContainerIdHolder> containerIdHolderMock = new();
+            Mock<IPodInfoManager> podInfoManagerMock = new();
+            Mock<IContainerStatusManager> containerStatusManagerMock = new();
+            Mock<IK8sClientService> k8sClientServiceMock = new();
+
+            // Timeout
+            TimeSpan timeout = TimeSpan.FromMilliseconds(1);
+
+            // Simulate a spin waiting on pod info
+            podInfoManagerMock.Setup(p => p.WaitUntilMyPodReadyAsync(It.IsAny<CancellationToken>()))
+                .Returns<CancellationToken>(async (token) =>
+                {
+                    while (true)
+                    {
+                        await Task.Delay(timeout);  // This wait is optional, it is there so that the cancellation token check doesn't happen too early.
+                        token.ThrowIfCancellationRequested();
+                        await Task.Delay(TimeSpan.FromSeconds(1));
+                    }
+                });
+
+            K8sEnvironmentFactory target = new K8sEnvironmentFactory(containerIdHolderMock.Object, podInfoManagerMock.Object, containerStatusManagerMock.Object, k8sClientServiceMock.Object);
+
+            IK8sEnvironment environment = null;
+            CancellationToken timeoutToken;
+            using (CancellationTokenSource timeoutSource = new CancellationTokenSource(TimeSpan.FromMilliseconds(1)))
+            {
+                timeoutToken = timeoutSource.Token;
+                environment = await target.CreateAsync(timeoutToken);
+            }
+
+            Assert.True(timeoutToken.IsCancellationRequested);
+            Assert.Null(environment);
+        }
+
+        [Fact]
+        public async Task ShouldTimeoutWaitingContainerReady()
+        {
+            Mock<IContainerIdHolder> containerIdHolderMock = new();
+            Mock<IPodInfoManager> podInfoManagerMock = new();
+            Mock<IContainerStatusManager> containerStatusManagerMock = new();
+            Mock<IK8sClientService> k8sClientServiceMock = new();
+
+            // Timeout
+            TimeSpan timeout = TimeSpan.FromMilliseconds(1);
+
+            // Pod will be returned.
+            V1Pod pod = new V1Pod();
+            podInfoManagerMock.Setup(p => p.WaitUntilMyPodReadyAsync(It.IsAny<CancellationToken>())).Returns(() => Task.FromResult(pod));
+
+            // Simulate a delay on getting container ready
+            containerStatusManagerMock.Setup(c => c.WaitContainerReadyAsync(It.IsAny<CancellationToken>()))
+            .Returns<CancellationToken>(async (token) =>
+            {
+                while (true)
+                {
+                    await Task.Delay(timeout);  // This wait is optional, it is there so that the cancellation token check doesn't happen too early.
+                    token.ThrowIfCancellationRequested();
+                    await Task.Delay(TimeSpan.FromSeconds(1));
+                }
+            });
+
+            K8sEnvironmentFactory target = new K8sEnvironmentFactory(containerIdHolderMock.Object, podInfoManagerMock.Object, containerStatusManagerMock.Object, k8sClientServiceMock.Object);
+
+            IK8sEnvironment environment = null;
+            CancellationToken timeoutToken;
+            using (CancellationTokenSource timeoutSource = new CancellationTokenSource(timeout))
+            {
+                timeoutToken = timeoutSource.Token;
+                environment = await target.CreateAsync(timeoutToken);
+            }
+
+            Assert.True(timeoutToken.IsCancellationRequested);
+            Assert.Null(environment);
+        }
+    }
+}

--- a/tests/UnitTests/KubernetesEnablementTests.cs
+++ b/tests/UnitTests/KubernetesEnablementTests.cs
@@ -1,5 +1,3 @@
-﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -37,99 +35,13 @@ public class KubernetesEnablementTest
         }
     }
 
-    [Fact(DisplayName = "Default timeout for waiting container to spin us is 2 minutes")]
-    public void EnableAppInsightsForKubernetesWithDefaultTimeOut()
-    {
-        Mock<IClusterEnvironmentCheck> clusterCheckMock = new();
-        IServiceCollection services = new ServiceCollection();
-        services.AddSingleton<IConfiguration>(p => new ConfigurationBuilder().Build());
-
-        clusterCheckMock.Setup(c => c.IsInCluster).Returns(true);
-
-        KubernetesServiceCollectionBuilder target = new KubernetesServiceCollectionBuilder(customizeOptions: null, clusterCheckMock.Object);
-        target.RegisterServices(services);
-
-        MockK8sTestEnvironment(services);
-
-        using (ServiceProvider serviceProvider = services.BuildServiceProvider())
-        {
-            KubernetesTelemetryInitializer targetTelemetryInitializer = serviceProvider.GetServices<ITelemetryInitializer>().First(ti => ti is KubernetesTelemetryInitializer) as KubernetesTelemetryInitializer;
-            Assert.StrictEqual(TimeSpan.FromMinutes(2), targetTelemetryInitializer.Options.InitializationTimeout);
-        }
-    }
-
-    [Fact(DisplayName = "Set timeout through options works for telemetry initializer.")]
-    public void EnableAppInsightsForKubernetesWithTimeOutSetThroughOptions()
-    {
-        Mock<IClusterEnvironmentCheck> clusterCheckMock = new();
-        clusterCheckMock.Setup(c => c.IsInCluster).Returns(true);
-
-        IServiceCollection services = new ServiceCollection();
-        services.AddSingleton<IConfiguration>(p => new ConfigurationBuilder().Build());
-        services.ConfigureKubernetesTelemetryInitializer(
-            overwriteOptions: option =>
-            {
-                option.InitializationTimeout = TimeSpan.FromSeconds(5);
-            }, clusterCheckMock.Object);
-
-        MockK8sTestEnvironment(services);
-
-        using (ServiceProvider serviceProvider = services.BuildServiceProvider())
-        {
-            ITelemetryInitializer targetTelemetryInitializer = serviceProvider.GetServices<ITelemetryInitializer>().First(i => i is KubernetesTelemetryInitializer);
-            if (targetTelemetryInitializer is KubernetesTelemetryInitializer target)
-            {
-                Assert.StrictEqual(TimeSpan.FromSeconds(5), target.Options.InitializationTimeout);
-            }
-            else
-            {
-                Assert.True(false, "Not the target telemetry initializer.");
-            }
-        }
-    }
-
-    [Fact(DisplayName = "Set timeout through configuration works for telemetry initializer.")]
-    public void EnableAppInsightsForKubernetesWithTimeOutSetThroughConfiguration()
-    {
-        Mock<IClusterEnvironmentCheck> clusterCheckMock = new();
-        clusterCheckMock.Setup(c => c.IsInCluster).Returns(true);
-
-        IServiceCollection services = new ServiceCollection();
-        IConfiguration config = new ConfigurationBuilder().AddInMemoryCollection(
-            new Dictionary<string, string>(){
-                    {"a" , "b"},
-                    {"AppInsightsForKubernetes:InitializationTimeout", "3.1:12:15.34"}
-        }).Build();
-        services.AddSingleton(config);
-        KubernetesServiceCollectionBuilder k8sServiceBuilder = new KubernetesServiceCollectionBuilder(customizeOptions: null, clusterCheckMock.Object);
-        k8sServiceBuilder.RegisterServices(services);
-
-        MockK8sTestEnvironment(services);
-
-        Assert.NotNull(services.FirstOrDefault(sd => sd.ImplementationType == typeof(KubernetesTelemetryInitializer)));
-
-        using (ServiceProvider serviceProvider = services.BuildServiceProvider())
-        {
-            ITelemetryInitializer targetTelemetryInitializer = serviceProvider.GetServices<ITelemetryInitializer>().FirstOrDefault(ti => ti is KubernetesTelemetryInitializer);
-
-            if (targetTelemetryInitializer is KubernetesTelemetryInitializer target)
-            {
-                Assert.StrictEqual(new TimeSpan(days: 3, hours: 1, minutes: 12, seconds: 15, milliseconds: 340), target.Options.InitializationTimeout);
-            }
-            else
-            {
-                Assert.True(false, "Not the target telemetry initializer.");
-            }
-        }
-    }
-
     private static void MockK8sTestEnvironment(IServiceCollection services)
     {
         // So that it doesn't require a real k8s cluster to get a K8s environment.
         services.AddSingleton<IK8sEnvironmentFactory>(p =>
         {
             Mock<IK8sEnvironmentFactory> k8sEnvFactoryMock = new();
-            k8sEnvFactoryMock.Setup(f => f.CreateAsync(It.IsAny<DateTime>(), It.IsAny<CancellationToken>())).Returns(() =>
+            k8sEnvFactoryMock.Setup(f => f.CreateAsync(It.IsAny<CancellationToken>())).Returns(() =>
             {
                 Mock<IK8sEnvironment> k8sEnv = new();
                 return Task.FromResult(k8sEnv.Object);


### PR DESCRIPTION
Addresses #301, #302 

Leverage background service for getting cluster-info.
  * Simplified the telemetry initializer
  * Enables refresh cluster-info by configured intervals.

Reimplement timeout by using a cancellation token than a stub task.

Piggyback some small refactors.
