### PR TITLE
Drop Newtonsoft.Json

### DIFF
--- a/src/ApplicationInsights.Kubernetes/ApplicationInsights.Kubernetes.csproj
+++ b/src/ApplicationInsights.Kubernetes/ApplicationInsights.Kubernetes.csproj
@@ -24,7 +24,6 @@
     <PackageReference Include="Microsoft.Extensions.DiagnosticAdapter" Version="3.1.27" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Drop explicit dependency to Newtonsoft.Json.
By investigation, Newtonsoft.Json is still on the dependency chain. The intention is:
1. No explicit dependency on it;
2. When we are ready to upgrade to use a higher version of `Kubernetes.Client`, it won't be a blocking issue;

The bottom line, is there is nothing functionally wrong with using `Newtonsoft.Json`.