### PR TITLE
Bump up unit test sdk to 17.4.0

### DIFF
--- a/tests/UnitTests/UnitTests.csproj
+++ b/tests/UnitTests/UnitTests.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="Moq" Version="4.*" />
     <PackageReference Include="xunit" Version="2.4.*" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.*" />


### PR DESCRIPTION
Addresses #329 
Brings up the dependency of Newtonsoft.Json to 13.0.1 from 9.0.1 for compliance.

New dependency graph:

![image](https://user-images.githubusercontent.com/3674549/201537659-63a672cf-3d6f-4966-b4b7-20598798c2b4.png)

