### PR TITLE
Support Multi-Targeting

### DIFF
--- a/dev/F5WebApi.Net31/.gitignore
+++ b/dev/F5WebApi.Net31/.gitignore
@@ -1,0 +1,2 @@
+Pkgs
+local.*

--- a/dev/F5WebApi.Net31/Controllers/WeatherForecastController.cs
+++ b/dev/F5WebApi.Net31/Controllers/WeatherForecastController.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+namespace F5WebApi.Net31.Controllers
+{
+    [ApiController]
+    [Route("[controller]")]
+    public class WeatherForecastController : ControllerBase
+    {
+        private static readonly string[] Summaries = new[]
+        {
+            "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
+        };
+
+        private readonly ILogger<WeatherForecastController> _logger;
+
+        public WeatherForecastController(ILogger<WeatherForecastController> logger)
+        {
+            _logger = logger;
+        }
+
+        [HttpGet]
+        public IEnumerable<WeatherForecast> Get()
+        {
+            var rng = new Random();
+            return Enumerable.Range(1, 5).Select(index => new WeatherForecast
+            {
+                Date = DateTime.Now.AddDays(index),
+                TemperatureC = rng.Next(-20, 55),
+                Summary = Summaries[rng.Next(Summaries.Length)]
+            })
+            .ToArray();
+        }
+    }
+}

--- a/dev/F5WebApi.Net31/F5WebApi.Net31.csproj
+++ b/dev/F5WebApi.Net31/F5WebApi.Net31.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <ItemGroup>
+    
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.Kubernetes" Version="3.0.0-private-*" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/dev/F5WebApi.Net31/Program.cs
+++ b/dev/F5WebApi.Net31/Program.cs
@@ -1,0 +1,20 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
+
+namespace F5WebApi.Net31
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            CreateHostBuilder(args).Build().Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseStartup<Startup>();
+                });
+    }
+}

--- a/dev/F5WebApi.Net31/Properties/launchSettings.json
+++ b/dev/F5WebApi.Net31/Properties/launchSettings.json
@@ -1,0 +1,14 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "F5WebApi.Net31": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "launchUrl": "weatherforecast",
+      "applicationUrl": "https://localhost:5001;http://localhost:5000",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/dev/F5WebApi.Net31/Startup.cs
+++ b/dev/F5WebApi.Net31/Startup.cs
@@ -1,0 +1,48 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace F5WebApi.Net31
+{
+    public class Startup
+    {
+        public Startup(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
+        public IConfiguration Configuration { get; }
+
+        // This method gets called by the runtime. Use this method to add services to the container.
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddControllers();
+
+            services.AddApplicationInsightsTelemetry();
+            services.AddApplicationInsightsKubernetesEnricher(diagnosticLogLevel: LogLevel.Debug);
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+
+            app.UseHttpsRedirection();
+
+            app.UseRouting();
+
+            app.UseAuthorization();
+
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapControllers();
+            });
+        }
+    }
+}

--- a/dev/F5WebApi.Net31/WeatherForecast.cs
+++ b/dev/F5WebApi.Net31/WeatherForecast.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace F5WebApi.Net31
+{
+    public class WeatherForecast
+    {
+        public DateTime Date { get; set; }
+
+        public int TemperatureC { get; set; }
+
+        public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+
+        public string Summary { get; set; }
+    }
+}

--- a/dev/F5WebApi.Net31/appsettings.Development.json
+++ b/dev/F5WebApi.Net31/appsettings.Development.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  }
+}

--- a/dev/F5WebApi.Net31/appsettings.json
+++ b/dev/F5WebApi.Net31/appsettings.json
@@ -1,0 +1,10 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/dev/F5WebApi.Net31/dockerfile
+++ b/dev/F5WebApi.Net31/dockerfile
@@ -1,0 +1,5 @@
+  # syntax=docker/dockerfile:1
+  FROM mcr.microsoft.com/dotnet/aspnet:3.1
+  COPY bin/Release/netcoreapp3.1/publish/ App/
+  WORKDIR /App
+  ENTRYPOINT ["dotnet", "F5WebApi.Net31.dll"]

--- a/dev/F5WebApi.Net31/nuget.config
+++ b/dev/F5WebApi.Net31/nuget.config
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+    <add key="local" value="Pkgs" />
+    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/dev/F5WebApi/F5WebApi.csproj
+++ b/dev/F5WebApi/F5WebApi.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.*" />
+    <PackageReference Include="KubernetesClient" Version="10.0.16" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ApplicationInsights.Kubernetes.HostingStartup/ApplicationInsights.Kubernetes.HostingStartup.csproj
+++ b/src/ApplicationInsights.Kubernetes.HostingStartup/ApplicationInsights.Kubernetes.HostingStartup.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
     <AssemblyName>Microsoft.ApplicationInsights.Kubernetes.HostingStartup</AssemblyName>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
 
@@ -15,7 +15,7 @@
     <!-- Explicit reference Microsoft.AspNetCore.Hosting even though it would be brought in by dependencies. -->
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.2.7" />
     
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="$(ApplicationInsights_PackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ApplicationInsights.Kubernetes/ApplicationInsights.Kubernetes.csproj
+++ b/src/ApplicationInsights.Kubernetes/ApplicationInsights.Kubernetes.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.21.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="$(ApplicationInsights_PackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />

--- a/src/ApplicationInsights.Kubernetes/ApplicationInsights.Kubernetes.csproj
+++ b/src/ApplicationInsights.Kubernetes/ApplicationInsights.Kubernetes.csproj
@@ -3,7 +3,7 @@
     <Features>IOperation</Features>
   </PropertyGroup>
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
     <RootNamespace>Microsoft.ApplicationInsights.Kubernetes</RootNamespace>
     <AssemblyName>Microsoft.ApplicationInsights.Kubernetes</AssemblyName>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -16,8 +16,17 @@
     <PackageReadmeFile>Readme.Nuget.md</PackageReadmeFile>
   </PropertyGroup>
 
-  <ItemGroup>
+  <!-- .NET Standard 2.1 specific packages -->
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
+    <PackageReference Include="KubernetesClient" Version="[7.2.19, 8.0.0)" />
+  </ItemGroup>
+
+  <!-- .NET 6 specific packages -->
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
     <PackageReference Include="KubernetesClient" Version="[10.0.16, 11.0.0)" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.21.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />

--- a/src/ApplicationInsights.Kubernetes/ApplicationInsights.Kubernetes.csproj
+++ b/src/ApplicationInsights.Kubernetes/ApplicationInsights.Kubernetes.csproj
@@ -3,7 +3,7 @@
     <Features>IOperation</Features>
   </PropertyGroup>
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Microsoft.ApplicationInsights.Kubernetes</RootNamespace>
     <AssemblyName>Microsoft.ApplicationInsights.Kubernetes</AssemblyName>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="KubernetesClient" Version="7.2.19" />
+    <PackageReference Include="KubernetesClient" Version="[10.0.16, 11.0.0)" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.21.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
@@ -25,10 +25,6 @@
     <PackageReference Include="Microsoft.Extensions.DiagnosticAdapter" Version="3.1.27" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Compile Remove="Extensions\ObsoletedExtensions.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ApplicationInsights.Kubernetes/Extensions/ApplicationInsightsExtensions.cs
+++ b/src/ApplicationInsights.Kubernetes/Extensions/ApplicationInsightsExtensions.cs
@@ -28,7 +28,6 @@ namespace Microsoft.Extensions.DependencyInjection
             LogLevel? diagnosticLogLevel = LogLevel.None,
             IClusterEnvironmentCheck? clusterCheck = default)
         {
-            diagnosticLogLevel ??= LogLevel.None;   // Default to None.
             if (diagnosticLogLevel != LogLevel.None)
             {
                 ApplicationInsightsKubernetesDiagnosticObserver observer = new ApplicationInsightsKubernetesDiagnosticObserver((DiagnosticLogLevel)diagnosticLogLevel);

--- a/src/ApplicationInsights.Kubernetes/K8sClientService.cs
+++ b/src/ApplicationInsights.Kubernetes/K8sClientService.cs
@@ -49,22 +49,22 @@ internal sealed class K8sClientService : IDisposable, IK8sClientService
 
     public async Task<IEnumerable<V1Pod>> GetPodsAsync(CancellationToken cancellationToken)
     {
-        V1PodList? list = await _kubernetesClient.ListNamespacedPodAsync(_namespace, cancellationToken: cancellationToken).ConfigureAwait(false);
+        V1PodList? list = await _kubernetesClient.CoreV1.ListNamespacedPodAsync(_namespace, cancellationToken: cancellationToken).ConfigureAwait(false);
         return list.AsEnumerable();
     }
 
     public Task<V1Pod?> GetPodByNameAsync(string podName, CancellationToken cancellationToken)
-        => _kubernetesClient.ReadNamespacedPodAsync(podName, _namespace, cancellationToken: cancellationToken);
+        => _kubernetesClient.CoreV1.ReadNamespacedPodAsync(podName, _namespace, cancellationToken: cancellationToken);
 
     public async Task<IEnumerable<V1ReplicaSet>> GetReplicaSetsAsync(CancellationToken cancellationToken)
     {
-        V1ReplicaSetList? replicaSetList = await _kubernetesClient.ListNamespacedReplicaSetAsync(_namespace, cancellationToken: cancellationToken).ConfigureAwait(false);
+        V1ReplicaSetList? replicaSetList = await _kubernetesClient.AppsV1.ListNamespacedReplicaSetAsync(_namespace, cancellationToken: cancellationToken).ConfigureAwait(false);
         return replicaSetList.AsEnumerable();
     }
 
     public async Task<IEnumerable<V1Deployment>> GetDeploymentsAsync(CancellationToken cancellationToken)
     {
-        V1DeploymentList? deploymentList = await _kubernetesClient.ListNamespacedDeploymentAsync(_namespace, cancellationToken: cancellationToken).ConfigureAwait(false);
+        V1DeploymentList? deploymentList = await _kubernetesClient.AppsV1.ListNamespacedDeploymentAsync(_namespace, cancellationToken: cancellationToken).ConfigureAwait(false);
         return deploymentList.AsEnumerable();
     }
 
@@ -72,7 +72,7 @@ internal sealed class K8sClientService : IDisposable, IK8sClientService
     {
         try
         {
-            V1NodeList? nodeList = await _kubernetesClient.ListNodeAsync();
+            V1NodeList? nodeList = await _kubernetesClient.CoreV1.ListNodeAsync().ConfigureAwait(false);
             return nodeList.AsEnumerable();
         }
         catch (HttpOperationException ex) when (ex.Response.StatusCode == HttpStatusCode.Forbidden)

--- a/src/ApplicationInsights.Kubernetes/K8sClientService.cs
+++ b/src/ApplicationInsights.Kubernetes/K8sClientService.cs
@@ -49,22 +49,38 @@ internal sealed class K8sClientService : IDisposable, IK8sClientService
 
     public async Task<IEnumerable<V1Pod>> GetPodsAsync(CancellationToken cancellationToken)
     {
+#if NETSTANDARD2_1
+        V1PodList? list = await _kubernetesClient.ListNamespacedPodAsync(_namespace, cancellationToken: cancellationToken).ConfigureAwait(false);
+#else
         V1PodList? list = await _kubernetesClient.CoreV1.ListNamespacedPodAsync(_namespace, cancellationToken: cancellationToken).ConfigureAwait(false);
+#endif
         return list.AsEnumerable();
     }
 
     public Task<V1Pod?> GetPodByNameAsync(string podName, CancellationToken cancellationToken)
-        => _kubernetesClient.CoreV1.ReadNamespacedPodAsync(podName, _namespace, cancellationToken: cancellationToken);
+#if NETSTANDARD2_1
+            => _kubernetesClient.ReadNamespacedPodAsync(podName, _namespace, cancellationToken: cancellationToken);
+#else
+            => _kubernetesClient.CoreV1.ReadNamespacedPodAsync(podName, _namespace, cancellationToken: cancellationToken);
+#endif
 
     public async Task<IEnumerable<V1ReplicaSet>> GetReplicaSetsAsync(CancellationToken cancellationToken)
     {
+#if NETSTANDARD2_1
+        V1ReplicaSetList? replicaSetList = await _kubernetesClient.ListNamespacedReplicaSetAsync(_namespace, cancellationToken: cancellationToken).ConfigureAwait(false);
+#else
         V1ReplicaSetList? replicaSetList = await _kubernetesClient.AppsV1.ListNamespacedReplicaSetAsync(_namespace, cancellationToken: cancellationToken).ConfigureAwait(false);
+#endif
         return replicaSetList.AsEnumerable();
     }
 
     public async Task<IEnumerable<V1Deployment>> GetDeploymentsAsync(CancellationToken cancellationToken)
     {
+#if NETSTANDARD2_1
+        V1DeploymentList? deploymentList = await _kubernetesClient.ListNamespacedDeploymentAsync(_namespace, cancellationToken: cancellationToken).ConfigureAwait(false);
+#else
         V1DeploymentList? deploymentList = await _kubernetesClient.AppsV1.ListNamespacedDeploymentAsync(_namespace, cancellationToken: cancellationToken).ConfigureAwait(false);
+#endif
         return deploymentList.AsEnumerable();
     }
 
@@ -72,7 +88,11 @@ internal sealed class K8sClientService : IDisposable, IK8sClientService
     {
         try
         {
+#if NETSTANDARD2_1
+            V1NodeList? nodeList = await _kubernetesClient.ListNodeAsync().ConfigureAwait(false);
+#else
             V1NodeList? nodeList = await _kubernetesClient.CoreV1.ListNodeAsync().ConfigureAwait(false);
+#endif
             return nodeList.AsEnumerable();
         }
         catch (HttpOperationException ex) when (ex.Response.StatusCode == HttpStatusCode.Forbidden)

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -19,8 +19,8 @@
         <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)PublicKey.snk</AssemblyOriginatorKeyFile>
         <!--Package-->
         <VersionSuffix Condition=" '$(VersionSuffix)' == '' ">$([System.DateTime]::Now.ToString(yyyyMMddHHmm))</VersionSuffix>
-        <Version Condition=" '$(Version)' == '' ">6.0.0-private-$(VersionSuffix)</Version>
-        <AssemblyVersion Condition=" '$(AssemblyVersion)' == '' ">6.0.0.0</AssemblyVersion>
+        <Version Condition=" '$(Version)' == '' ">3.0.0-private-$(VersionSuffix)</Version>
+        <AssemblyVersion Condition=" '$(AssemblyVersion)' == '' ">3.0.0.0</AssemblyVersion>
         <Authors>Microsoft</Authors>
         <Company>Microsoft</Company>
         <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,6 +4,11 @@
     <PropertyGroup>
         <LangVersion>10.0</LangVersion>
         <Nullable>enable</Nullable>
+
+        <!-- Unified NuGet package reference versions. Pull out to standalone build props file when
+        it grows. -->
+        <!-- Application Insights SDK and Application Insights for ASP.NET Core version. -->
+        <ApplicationInsights_PackageVersion>2.21.0</ApplicationInsights_PackageVersion>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
         <OutputPath>$(MSBuildThisFileDirectory)..\bin\Debug\</OutputPath>
@@ -18,7 +23,8 @@
         <DelaySign>True</DelaySign>
         <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)PublicKey.snk</AssemblyOriginatorKeyFile>
         <!--Package-->
-        <VersionSuffix Condition=" '$(VersionSuffix)' == '' ">$([System.DateTime]::Now.ToString(yyyyMMddHHmm))</VersionSuffix>
+        <VersionSuffix Condition=" '$(VersionSuffix)' == '' ">
+            $([System.DateTime]::Now.ToString(yyyyMMddHHmm))</VersionSuffix>
         <Version Condition=" '$(Version)' == '' ">3.0.0-private-$(VersionSuffix)</Version>
         <AssemblyVersion Condition=" '$(AssemblyVersion)' == '' ">3.0.0.0</AssemblyVersion>
         <Authors>Microsoft</Authors>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -23,8 +23,7 @@
         <DelaySign>True</DelaySign>
         <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)PublicKey.snk</AssemblyOriginatorKeyFile>
         <!--Package-->
-        <VersionSuffix Condition=" '$(VersionSuffix)' == '' ">
-            $([System.DateTime]::Now.ToString(yyyyMMddHHmm))</VersionSuffix>
+        <VersionSuffix Condition=" '$(VersionSuffix)' == '' ">$([System.DateTime]::Now.ToString(yyyyMMddHHmm))</VersionSuffix>
         <Version Condition=" '$(Version)' == '' ">3.0.0-private-$(VersionSuffix)</Version>
         <AssemblyVersion Condition=" '$(AssemblyVersion)' == '' ">3.0.0.0</AssemblyVersion>
         <Authors>Microsoft</Authors>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -19,8 +19,8 @@
         <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)PublicKey.snk</AssemblyOriginatorKeyFile>
         <!--Package-->
         <VersionSuffix Condition=" '$(VersionSuffix)' == '' ">$([System.DateTime]::Now.ToString(yyyyMMddHHmm))</VersionSuffix>
-        <Version Condition=" '$(Version)' == '' ">3.0.0-private-$(VersionSuffix)</Version>
-        <AssemblyVersion Condition=" '$(AssemblyVersion)' == '' ">3.0.0.0</AssemblyVersion>
+        <Version Condition=" '$(Version)' == '' ">6.0.0-private-$(VersionSuffix)</Version>
+        <AssemblyVersion Condition=" '$(AssemblyVersion)' == '' ">6.0.0.0</AssemblyVersion>
         <Authors>Microsoft</Authors>
         <Company>Microsoft</Company>
         <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>


### PR DESCRIPTION
Address #332.

1. For .NET 6 applications, `K8s.Client.10.0.16+` will be depended on;
2. For .NET 3.1 applications, it will stay on `7.x` for backward compatibility;

This is a short-term solution until .NET Core 3.1 is phased out of the system.

Piggyback on:
* an F5 project to allow quick covering .NET Core 3.1 - under folder /dev/F5WebApi.Net31.
* small bug fixes.

