### PR TITLE
Application Insights for Kubernetes 6.0

### DIFF
--- a/dev/F5WebApi/F5WebApi.csproj
+++ b/dev/F5WebApi/F5WebApi.csproj
@@ -11,7 +11,6 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.*" />
-    <PackageReference Include="KubernetesClient" Version="10.0.16" />
   </ItemGroup>
 
   <ItemGroup>

--- a/dev/F5WebApi/F5WebApi.csproj
+++ b/dev/F5WebApi/F5WebApi.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.*" />
+    <PackageReference Include="KubernetesClient" Version="10.0.16" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ApplicationInsights.Kubernetes/ApplicationInsights.Kubernetes.csproj
+++ b/src/ApplicationInsights.Kubernetes/ApplicationInsights.Kubernetes.csproj
@@ -3,7 +3,7 @@
     <Features>IOperation</Features>
   </PropertyGroup>
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Microsoft.ApplicationInsights.Kubernetes</RootNamespace>
     <AssemblyName>Microsoft.ApplicationInsights.Kubernetes</AssemblyName>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="KubernetesClient" Version="7.2.19" />
+    <PackageReference Include="KubernetesClient" Version="[10.0.16, 11.0.0)" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.21.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
@@ -25,10 +25,6 @@
     <PackageReference Include="Microsoft.Extensions.DiagnosticAdapter" Version="3.1.27" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Compile Remove="Extensions\ObsoletedExtensions.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ApplicationInsights.Kubernetes/K8sClientService.cs
+++ b/src/ApplicationInsights.Kubernetes/K8sClientService.cs
@@ -49,22 +49,22 @@ internal sealed class K8sClientService : IDisposable, IK8sClientService
 
     public async Task<IEnumerable<V1Pod>> GetPodsAsync(CancellationToken cancellationToken)
     {
-        V1PodList? list = await _kubernetesClient.ListNamespacedPodAsync(_namespace, cancellationToken: cancellationToken).ConfigureAwait(false);
+        V1PodList? list = await _kubernetesClient.CoreV1.ListNamespacedPodAsync(_namespace, cancellationToken: cancellationToken).ConfigureAwait(false);
         return list.AsEnumerable();
     }
 
     public Task<V1Pod?> GetPodByNameAsync(string podName, CancellationToken cancellationToken)
-        => _kubernetesClient.ReadNamespacedPodAsync(podName, _namespace, cancellationToken: cancellationToken);
+        => _kubernetesClient.CoreV1.ReadNamespacedPodAsync(podName, _namespace, cancellationToken: cancellationToken);
 
     public async Task<IEnumerable<V1ReplicaSet>> GetReplicaSetsAsync(CancellationToken cancellationToken)
     {
-        V1ReplicaSetList? replicaSetList = await _kubernetesClient.ListNamespacedReplicaSetAsync(_namespace, cancellationToken: cancellationToken).ConfigureAwait(false);
+        V1ReplicaSetList? replicaSetList = await _kubernetesClient.AppsV1.ListNamespacedReplicaSetAsync(_namespace, cancellationToken: cancellationToken).ConfigureAwait(false);
         return replicaSetList.AsEnumerable();
     }
 
     public async Task<IEnumerable<V1Deployment>> GetDeploymentsAsync(CancellationToken cancellationToken)
     {
-        V1DeploymentList? deploymentList = await _kubernetesClient.ListNamespacedDeploymentAsync(_namespace, cancellationToken: cancellationToken).ConfigureAwait(false);
+        V1DeploymentList? deploymentList = await _kubernetesClient.AppsV1.ListNamespacedDeploymentAsync(_namespace, cancellationToken: cancellationToken).ConfigureAwait(false);
         return deploymentList.AsEnumerable();
     }
 
@@ -72,7 +72,7 @@ internal sealed class K8sClientService : IDisposable, IK8sClientService
     {
         try
         {
-            V1NodeList? nodeList = await _kubernetesClient.ListNodeAsync();
+            V1NodeList? nodeList = await _kubernetesClient.CoreV1.ListNodeAsync().ConfigureAwait(false);
             return nodeList.AsEnumerable();
         }
         catch (HttpOperationException ex) when (ex.Response.StatusCode == HttpStatusCode.Forbidden)

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -19,8 +19,8 @@
         <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)PublicKey.snk</AssemblyOriginatorKeyFile>
         <!--Package-->
         <VersionSuffix Condition=" '$(VersionSuffix)' == '' ">$([System.DateTime]::Now.ToString(yyyyMMddHHmm))</VersionSuffix>
-        <Version Condition=" '$(Version)' == '' ">3.0.0-private-$(VersionSuffix)</Version>
-        <AssemblyVersion Condition=" '$(AssemblyVersion)' == '' ">3.0.0.0</AssemblyVersion>
+        <Version Condition=" '$(Version)' == '' ">6.0.0-private-$(VersionSuffix)</Version>
+        <AssemblyVersion Condition=" '$(AssemblyVersion)' == '' ">6.0.0.0</AssemblyVersion>
         <Authors>Microsoft</Authors>
         <Company>Microsoft</Company>
         <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>


### PR DESCRIPTION
Address #332 

* Bump up the major version to drop support for `.NET Core 3.1` for the newer packages.
  * `.NET Core 3.1` is out of support on 12/13/2023. For more info: <https://dot.net>

The existing 3.x package will be kept for a while so that there's time to mitigate existing projects to `6.x`. We will check the download data to determine when to fully remove `Microsoft.ApplicationInsights.Kubernets 3.x`.