### PR TITLE
Support In-Proc Azure Function in K8s

### DIFF
--- a/src/ApplicationInsights.Kubernetes/Extensions/ApplicationInsightsExtensions.cs
+++ b/src/ApplicationInsights.Kubernetes/Extensions/ApplicationInsightsExtensions.cs
@@ -19,14 +19,16 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </summary>
         /// <param name="services">Collection of service descriptors.</param>
         /// <param name="diagnosticLogLevel">Sets the diagnostics log levels for the enricher.</param>
-        /// <param name="skipRegisterBackendService">Allows skipping register any backend service for constrained environment like InProc Azure Function.</param>
+        /// <param name="disableBackgroundService">If true, the Application Insights enricher library will not use any background (hosted) services,
+        /// and Kubernetes information will not be fetched automatically. Hosted services are not allowed in some environments, e.g. Azure Function. 
+        /// For more information see https://github.com/Azure/azure-functions-host/issues/5447#issuecomment-575368316</param>
         /// <param name="applyOptions">Action to customize the configuration of Application Insights for Kubernetes.</param>
         /// <param name="clusterCheck">Provides a custom implementation to check whether it is inside kubernetes cluster or not.</param>
         /// <returns>The service collection for chaining the next operation.</returns>
         public static IServiceCollection AddApplicationInsightsKubernetesEnricher(
             this IServiceCollection services,
             LogLevel? diagnosticLogLevel = LogLevel.None,
-            bool skipRegisterBackendService = false,
+            bool disableBackgroundService = false,
             Action<AppInsightsForKubernetesOptions>? applyOptions = default,
             IClusterEnvironmentCheck? clusterCheck = default)
         {
@@ -39,7 +41,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             if (!KubernetesTelemetryInitializerExists(services))
             {
-                services.ConfigureKubernetesTelemetryInitializer(applyOptions, clusterCheck, skipRegisterBackendService);
+                services.ConfigureKubernetesTelemetryInitializer(applyOptions, clusterCheck, disableBackgroundService);
             }
             return services;
         }

--- a/src/ApplicationInsights.Kubernetes/Extensions/ApplicationInsightsExtensions.cs
+++ b/src/ApplicationInsights.Kubernetes/Extensions/ApplicationInsightsExtensions.cs
@@ -18,14 +18,16 @@ namespace Microsoft.Extensions.DependencyInjection
         /// Enables Application Insights for Kubernetes on the Default TelemetryConfiguration in the dependency injection container with custom options.
         /// </summary>
         /// <param name="services">Collection of service descriptors.</param>
-        /// <param name="applyOptions">Action to customize the configuration of Application Insights for Kubernetes.</param>
         /// <param name="diagnosticLogLevel">Sets the diagnostics log levels for the enricher.</param>
+        /// <param name="skipRegisterBackendService">Allows skipping register any backend service for constrained environment like InProc Azure Function.</param>
+        /// <param name="applyOptions">Action to customize the configuration of Application Insights for Kubernetes.</param>
         /// <param name="clusterCheck">Provides a custom implementation to check whether it is inside kubernetes cluster or not.</param>
         /// <returns>The service collection for chaining the next operation.</returns>
         public static IServiceCollection AddApplicationInsightsKubernetesEnricher(
             this IServiceCollection services,
-            Action<AppInsightsForKubernetesOptions>? applyOptions = default,
             LogLevel? diagnosticLogLevel = LogLevel.None,
+            bool skipRegisterBackendService = false,
+            Action<AppInsightsForKubernetesOptions>? applyOptions = default,
             IClusterEnvironmentCheck? clusterCheck = default)
         {
             diagnosticLogLevel ??= LogLevel.None;   // Default to None.
@@ -37,7 +39,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             if (!KubernetesTelemetryInitializerExists(services))
             {
-                services.ConfigureKubernetesTelemetryInitializer(applyOptions, clusterCheck);
+                services.ConfigureKubernetesTelemetryInitializer(applyOptions, clusterCheck, skipRegisterBackendService);
             }
             return services;
         }
@@ -48,7 +50,7 @@ namespace Microsoft.Extensions.DependencyInjection
         public static void StartApplicationInsightsKubernetesEnricher(this IServiceProvider serviceProvider)
         {
             IK8sInfoBootstrap? k8sInfoBootstrap = serviceProvider.GetService<IK8sInfoBootstrap>();
-            if(k8sInfoBootstrap is null)
+            if (k8sInfoBootstrap is null)
             {
                 _logger.LogInformation("No service registered by type {0}. Either not running in a Kubernetes cluster or `{1}()` wasn't called on the service collection.", nameof(IK8sInfoBootstrap), nameof(AddApplicationInsightsKubernetesEnricher));
                 return;
@@ -69,9 +71,10 @@ namespace Microsoft.Extensions.DependencyInjection
         internal static void ConfigureKubernetesTelemetryInitializer(
             this IServiceCollection services,
             Action<AppInsightsForKubernetesOptions>? overwriteOptions,
-            IClusterEnvironmentCheck? clusterCheck)
+            IClusterEnvironmentCheck? clusterCheck,
+            bool skipRegisterBackendService = false)
         {
-            IKubernetesServiceCollectionBuilder kubernetesServiceCollectionBuilder = new KubernetesServiceCollectionBuilder(overwriteOptions, clusterCheck);
+            IKubernetesServiceCollectionBuilder kubernetesServiceCollectionBuilder = new KubernetesServiceCollectionBuilder(overwriteOptions, clusterCheck, skipRegisterBackendService);
             _ = kubernetesServiceCollectionBuilder.RegisterServices(services);
         }
     }

--- a/src/ApplicationInsights.Kubernetes/Extensions/KubernetesServiceCollectionBuilder.cs
+++ b/src/ApplicationInsights.Kubernetes/Extensions/KubernetesServiceCollectionBuilder.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Extensions.DependencyInjection;
 internal class KubernetesServiceCollectionBuilder : IKubernetesServiceCollectionBuilder
 {
     private readonly IClusterEnvironmentCheck _clusterCheck;
+    private readonly bool _skipRegisterBackendService;
     private readonly Action<AppInsightsForKubernetesOptions>? _customizeOptions;
     private readonly ApplicationInsightsKubernetesDiagnosticSource _logger = ApplicationInsightsKubernetesDiagnosticSource.Instance;
 
@@ -29,10 +30,12 @@ internal class KubernetesServiceCollectionBuilder : IKubernetesServiceCollection
     /// </param>
     public KubernetesServiceCollectionBuilder(
         Action<AppInsightsForKubernetesOptions>? customizeOptions,
-        IClusterEnvironmentCheck? clusterCheck)
+        IClusterEnvironmentCheck? clusterCheck,
+        bool skipRegisterBackendService)
     {
         _customizeOptions = customizeOptions;
         _clusterCheck = clusterCheck ?? new ClusterEnvironmentCheck();
+        _skipRegisterBackendService = skipRegisterBackendService;
     }
 
     /// <summary>
@@ -142,7 +145,13 @@ internal class KubernetesServiceCollectionBuilder : IKubernetesServiceCollection
         serviceCollection.TryAddScoped<IK8sEnvironmentFactory, K8sEnvironmentFactory>();
         serviceCollection.TryAddSingleton<IK8sEnvironmentHolder>(_ => K8sEnvironmentHolder.Instance);
 
+        _logger.LogTrace("Registering bootstrap and hosted service.");
         serviceCollection.TryAddSingleton<IK8sInfoBootstrap, K8sInfoBootstrap>();
-        serviceCollection.AddHostedService<K8sInfoBackgroundService>();
+        if (!_skipRegisterBackendService)
+        {
+            _logger.LogInformation("Skip registering {0} by user configuration.", nameof(K8sInfoBackgroundService));
+            serviceCollection.AddHostedService<K8sInfoBackgroundService>();
+        }
+        _logger.LogTrace("Registered bootstrap and hosted service.");
     }
 }

--- a/src/ApplicationInsights.Kubernetes/IK8sInfoBootstrap.cs
+++ b/src/ApplicationInsights.Kubernetes/IK8sInfoBootstrap.cs
@@ -8,7 +8,7 @@ namespace Microsoft.ApplicationInsights.Kubernetes;
 /// The intention is for the client to have a handle to start getting Kubernetes info to be consumed by the <see cref="IK8sInfoService" />.
 /// Remark: This is supposed to only be used in Console Application. Do NOT use this in ASP.NET or Worker, where the hosted service exists.
 /// </summary>
-internal interface IK8sInfoBootstrap
+public interface IK8sInfoBootstrap
 {
     /// <summary>
     /// Bootstrap the fetch of Kubernetes information.

--- a/tests/UnitTests/AppInsightsKubernetesOptionsTests.cs
+++ b/tests/UnitTests/AppInsightsKubernetesOptionsTests.cs
@@ -18,7 +18,7 @@ public class AppInsightsKubernetesOptionsTests
 
         clusterCheck.Setup(c => c.IsInCluster).Returns(true);
 
-        KubernetesServiceCollectionBuilder builder = new KubernetesServiceCollectionBuilder(customizeOptions: default, clusterCheck.Object);
+        KubernetesServiceCollectionBuilder builder = new KubernetesServiceCollectionBuilder(customizeOptions: default, clusterCheck.Object, skipRegisterBackendService: false);
 
         IServiceCollection services = new ServiceCollection();
         IConfiguration configuration = (new ConfigurationBuilder()).Build();
@@ -44,7 +44,7 @@ public class AppInsightsKubernetesOptionsTests
 
         clusterCheck.Setup(c => c.IsInCluster).Returns(true);
 
-        KubernetesServiceCollectionBuilder builder = new KubernetesServiceCollectionBuilder(customizeOptions: default, clusterCheck.Object);
+        KubernetesServiceCollectionBuilder builder = new KubernetesServiceCollectionBuilder(customizeOptions: default, clusterCheck.Object, skipRegisterBackendService: false);
 
         IServiceCollection services = new ServiceCollection();
         IConfiguration configuration = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string>()
@@ -71,7 +71,7 @@ public class AppInsightsKubernetesOptionsTests
         KubernetesServiceCollectionBuilder builder = new KubernetesServiceCollectionBuilder(customizeOptions: opt =>
         {
             opt.InitializationTimeout = TimeSpan.FromSeconds(10);   // The user settings through code will take precedence.
-        }, clusterCheck.Object);
+        }, clusterCheck.Object, skipRegisterBackendService: false);
 
         IServiceCollection services = new ServiceCollection();
         IConfiguration configuration = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string>()
@@ -101,7 +101,7 @@ public class AppInsightsKubernetesOptionsTests
         KubernetesServiceCollectionBuilder builder = new KubernetesServiceCollectionBuilder(customizeOptions: opt =>
         {
             opt.TelemetryKeyProcessor = keyTransformer;
-        }, clusterCheck.Object);
+        }, clusterCheck.Object, skipRegisterBackendService: false);
 
         IServiceCollection services = new ServiceCollection();
         IConfiguration configuration = new ConfigurationBuilder().Build();

--- a/tests/UnitTests/ApplicationInsightsExtensionsTests.cs
+++ b/tests/UnitTests/ApplicationInsightsExtensionsTests.cs
@@ -64,7 +64,7 @@ public class ApplicationInsightsExtensionsTests
     [Theory]
     [InlineData(false, true)]
     [InlineData(true, false)]
-    public void ShouldNotRegisterHostedServiceWhenSet(bool skipRegisterBackendService, bool expectServiceRegistered)
+    public void ShouldNotRegisterHostedServiceWhenSet(bool disableBackgroundService, bool expectServiceRegistered)
     {
         IServiceCollection collection = new ServiceCollection();
 
@@ -72,7 +72,7 @@ public class ApplicationInsightsExtensionsTests
         clusterCheck.Setup(c => c.IsInCluster).Returns(true);
 
         // If there's compile error, check if the signature of AddApplicationInsightsKubernetesEnricher was changed.
-        collection = collection.AddApplicationInsightsKubernetesEnricher(skipRegisterBackendService: skipRegisterBackendService, clusterCheck: clusterCheck.Object);
+        collection = collection.AddApplicationInsightsKubernetesEnricher(disableBackgroundService: disableBackgroundService, clusterCheck: clusterCheck.Object);
 
         Assert.NotNull(collection);
         bool registered = collection.Any(serviceDescriptor => serviceDescriptor.ServiceType == typeof(IHostedService));

--- a/tests/UnitTests/KubernetesEnablementTests.cs
+++ b/tests/UnitTests/KubernetesEnablementTests.cs
@@ -21,7 +21,7 @@ public class KubernetesEnablementTest
 
         clusterCheckMock.Setup(c => c.IsInCluster).Returns(true);
 
-        KubernetesServiceCollectionBuilder target = new KubernetesServiceCollectionBuilder(customizeOptions: null, clusterCheckMock.Object);
+        KubernetesServiceCollectionBuilder target = new KubernetesServiceCollectionBuilder(customizeOptions: null, clusterCheckMock.Object, skipRegisterBackendService: false);
         target.RegisterServices(services);
 
         Assert.NotNull(services.FirstOrDefault(sd => sd.ImplementationType == typeof(KubernetesTelemetryInitializer)));


### PR DESCRIPTION
There is a limitation that there can't be any HostedService registered in the dependency injection container in in-proc Azure Function.

This is an update to:
1. Allow the user to choose to skip registering the BackendService.
2. Expose `IK8sInfoBootstrap` as an alternative to allow the user to invoke it manually.

I would need to provide documentation in the future for the usage.

Tagging @mavsankar since he's asking for the feature.