### PR TITLE
Container id shall be optional

### DIFF
--- a/src/ApplicationInsights.Kubernetes/Containers/IContainerStatusManager.cs
+++ b/src/ApplicationInsights.Kubernetes/Containers/IContainerStatusManager.cs
@@ -6,7 +6,16 @@ namespace Microsoft.ApplicationInsights.Kubernetes.Containers;
 
 internal interface IContainerStatusManager
 {
+    /// <summary>
+    /// Gets my container status when available, or null.
+    /// </summary>
     Task<V1ContainerStatus?> GetMyContainerStatusAsync(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Gets whether my container is ready when the container id is available or check if any of the container's ready 
+    /// in case container id is missing.
+    /// </summary>
+    /// <param name="cancellationToken">The cancellation token.</param>
     Task<bool> IsContainerReadyAsync(CancellationToken cancellationToken);
 
     /// <summary>

--- a/tests/UnitTests/ContainerStatusManagerTests.cs
+++ b/tests/UnitTests/ContainerStatusManagerTests.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using k8s.Models;
+using Microsoft.ApplicationInsights.Kubernetes.Containers;
+using Microsoft.ApplicationInsights.Kubernetes.Pods;
+using Moq;
+using Xunit;
+
+namespace Microsoft.ApplicationInsights.Kubernetes.Tests;
+
+public class ContainerStatusManagerTests
+{
+    /// <summary>
+    /// Regression coverage: when there's no container id provided, falls back to use any container status in the pod.
+    /// </summary>
+    [Fact]
+    public async Task GetReadyWhenNoContainerId()
+    {
+        Mock<IPodInfoManager> podInfoManagerMock = new();
+        Mock<IContainerIdHolder> containerIdHolderMock = new();
+
+        // At least 1 container is ready.
+        V1Pod testPod = new V1Pod()
+        {
+            Status = new V1PodStatus()
+            {
+                ContainerStatuses = new List<V1ContainerStatus>(){
+                    new V1ContainerStatus(){
+                        Ready = true,
+                    }
+                }
+            }
+        };
+        podInfoManagerMock.Setup(p => p.GetMyPodAsync(It.IsAny<CancellationToken>())).Returns(Task.FromResult(testPod));
+
+        ContainerStatusManager containerStatusManager = new ContainerStatusManager(podInfoManagerMock.Object, containerIdHolderMock.Object);
+
+        using (CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(1)))
+        {
+            // My container status is absent since the container id is not available.
+            V1ContainerStatus myContainerStatus = await containerStatusManager.GetMyContainerStatusAsync(cancellationTokenSource.Token);
+            Assert.Null(myContainerStatus);
+
+            // Since there's a container ready:
+            bool isReady = await containerStatusManager.IsContainerReadyAsync(cancellationTokenSource.Token);
+            Assert.True(isReady);
+        }
+    }
+}


### PR DESCRIPTION
Trying to address #344 

This is a regression that when there are more than 1 container, and the container id can't be fetched, no telemetry enhancement.

That doesn't agree with the design intention that container id to be optional.

Fix by allowing container id to be absent but other telemetry enhancement still happens.

Here's an example of the logs after the fix:

```shell
[Warning] [2023-03-28T04:18:44.8583934Z] Can't fetch container id. Container id info will be missing. Please file an issue at https://github.com/microsoft/ApplicationInsights-Kubernetes/issues.
[Debug] [2023-03-28T04:18:44.9234011Z] {"ContainerID":null,"ContainerName":null,"PodName":"ai-k8s-f5webapi-deployment-77dc74c9dc-p75vq","PodID":"380deca3-e9c1-405f-b5b0-8e22660a8942","PodLabels":"app:ai-k8s-f5webapi,pod-template-hash:77dc74c9dc","PodNamespace":"ai-k8s-demo","ReplicaSetUid":"87f84c9c-55d2-47d5-82c1-dd6728454b25","ReplicaSetName":"ai-k8s-f5webapi-deployment-77dc74c9dc","DeploymentUid":"c1de6986-b3b1-4f98-b898-008246c0dff5","DeploymentName":"ai-k8s-f5webapi-deployment","NodeName":"docker-desktop","NodeUid":"cd59d76e-eaf2-4408-9083-aa2d76548055"}
```

