### PR TITLE
Ability to exclude node information

### DIFF
--- a/src/ApplicationInsights.Kubernetes/Extensions/AppInsightsForKubernetesOptions.cs
+++ b/src/ApplicationInsights.Kubernetes/Extensions/AppInsightsForKubernetesOptions.cs
@@ -53,5 +53,11 @@ namespace Microsoft.Extensions.DependencyInjection
         /// Default to false and look into totally get rid of it in the future.
         /// </summary>
         public bool OverwriteSDKVersion { get; set; }
+
+        /// <summary>
+        /// Exclude node information from cluster info by skipping calls to the nodes endpoint.
+        /// Default is false.
+        /// </summary>
+        public bool ExcludeNodeInformation { get; set; }
     }
 }

--- a/src/ApplicationInsights.Kubernetes/K8sEnvironmentFactory.cs
+++ b/src/ApplicationInsights.Kubernetes/K8sEnvironmentFactory.cs
@@ -23,7 +23,7 @@ internal class K8sEnvironmentFactory : IK8sEnvironmentFactory
     private readonly IPodInfoManager _podInfoManager;
     private readonly IContainerStatusManager _containerStatusManager;
     private readonly IK8sClientService _k8sClient;
-    private readonly IOptions<AppInsightsForKubernetesOptions> _options;
+    private readonly AppInsightsForKubernetesOptions _options;
 
     public K8sEnvironmentFactory(
         IContainerIdHolder containerIdHolder,
@@ -36,7 +36,7 @@ internal class K8sEnvironmentFactory : IK8sEnvironmentFactory
         _podInfoManager = podInfoManager ?? throw new ArgumentNullException(nameof(podInfoManager));
         _containerStatusManager = containerStatusManager ?? throw new ArgumentNullException(nameof(containerStatusManager));
         _k8sClient = k8sClient ?? throw new ArgumentNullException(nameof(k8sClient));
-        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
     }
 
     /// <summary>
@@ -63,7 +63,7 @@ internal class K8sEnvironmentFactory : IK8sEnvironmentFactory
 
             // Fetch node info
             V1Node? node = null;
-            if (!_options.Value.ExcludeNodeInformation)
+            if (!_options.ExcludeNodeInformation)
             {
                 string nodeName = myPod.Spec.NodeName;
                 IEnumerable<V1Node> allNodes = await _k8sClient.GetNodesAsync(ignoreForbiddenException: true, cancellationToken).ConfigureAwait(false);

--- a/src/ApplicationInsights.Kubernetes/K8sEnvironmentFactory.cs
+++ b/src/ApplicationInsights.Kubernetes/K8sEnvironmentFactory.cs
@@ -19,20 +19,17 @@ namespace Microsoft.ApplicationInsights.Kubernetes;
 internal class K8sEnvironmentFactory : IK8sEnvironmentFactory
 {
     private readonly ApplicationInsightsKubernetesDiagnosticSource _logger = ApplicationInsightsKubernetesDiagnosticSource.Instance;
-    private readonly IContainerIdHolder _containerIdHolder;
     private readonly IPodInfoManager _podInfoManager;
     private readonly IContainerStatusManager _containerStatusManager;
     private readonly IK8sClientService _k8sClient;
     private readonly AppInsightsForKubernetesOptions _options;
 
     public K8sEnvironmentFactory(
-        IContainerIdHolder containerIdHolder,
         IPodInfoManager podInfoManager,
         IContainerStatusManager containerStatusManager,
         IK8sClientService k8sClient,
         IOptions<AppInsightsForKubernetesOptions> options)
     {
-        _containerIdHolder = containerIdHolder ?? throw new ArgumentNullException(nameof(containerIdHolder));
         _podInfoManager = podInfoManager ?? throw new ArgumentNullException(nameof(podInfoManager));
         _containerStatusManager = containerStatusManager ?? throw new ArgumentNullException(nameof(containerStatusManager));
         _k8sClient = k8sClient ?? throw new ArgumentNullException(nameof(k8sClient));

--- a/tests/UnitTests/K8sEnvironemntFactoryTests.cs
+++ b/tests/UnitTests/K8sEnvironemntFactoryTests.cs
@@ -13,13 +13,18 @@ namespace Microsoft.ApplicationInsights.Kubernetes
 {
     public class K8sEnvironemntFactoryTests
     {
-        [Fact]
-        public async Task ShouldTimeoutWaitingPodReady()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task ShouldTimeoutWaitingPodReady(bool excludeNodeInformation)
         {
             Mock<IPodInfoManager> podInfoManagerMock = new();
             Mock<IContainerStatusManager> containerStatusManagerMock = new();
             Mock<IK8sClientService> k8sClientServiceMock = new();
             Mock<IOptions<AppInsightsForKubernetesOptions>> appInsightsForKubernetesOptionsMock = new();
+            appInsightsForKubernetesOptionsMock
+                .Setup(o => o.Value)
+                .Returns(new AppInsightsForKubernetesOptions { ExcludeNodeInformation = excludeNodeInformation });
 
             // Timeout
             TimeSpan timeout = TimeSpan.FromMilliseconds(1);
@@ -59,6 +64,9 @@ namespace Microsoft.ApplicationInsights.Kubernetes
             Mock<IContainerStatusManager> containerStatusManagerMock = new();
             Mock<IK8sClientService> k8sClientServiceMock = new();
             Mock<IOptions<AppInsightsForKubernetesOptions>> appInsightsForKubernetesOptionsMock = new();
+            appInsightsForKubernetesOptionsMock
+                .Setup(o => o.Value)
+                .Returns(new AppInsightsForKubernetesOptions());
 
             // Timeout
             TimeSpan timeout = TimeSpan.FromMilliseconds(1);

--- a/tests/UnitTests/K8sEnvironemntFactoryTests.cs
+++ b/tests/UnitTests/K8sEnvironemntFactoryTests.cs
@@ -16,7 +16,6 @@ namespace Microsoft.ApplicationInsights.Kubernetes
         [Fact]
         public async Task ShouldTimeoutWaitingPodReady()
         {
-            Mock<IContainerIdHolder> containerIdHolderMock = new();
             Mock<IPodInfoManager> podInfoManagerMock = new();
             Mock<IContainerStatusManager> containerStatusManagerMock = new();
             Mock<IK8sClientService> k8sClientServiceMock = new();
@@ -37,8 +36,8 @@ namespace Microsoft.ApplicationInsights.Kubernetes
                     }
                 });
 
-            K8sEnvironmentFactory target = new K8sEnvironmentFactory(containerIdHolderMock.Object,
-                podInfoManagerMock.Object, containerStatusManagerMock.Object, k8sClientServiceMock.Object,
+            K8sEnvironmentFactory target = new K8sEnvironmentFactory(podInfoManagerMock.Object,
+                containerStatusManagerMock.Object, k8sClientServiceMock.Object,
                 appInsightsForKubernetesOptionsMock.Object);
             IK8sEnvironment environment = null;
             CancellationToken timeoutToken;
@@ -56,7 +55,6 @@ namespace Microsoft.ApplicationInsights.Kubernetes
         [Obsolete("The scenario covered is deprecated", error: false)]
         public async Task ShouldTimeoutWaitingContainerReady()
         {
-            Mock<IContainerIdHolder> containerIdHolderMock = new();
             Mock<IPodInfoManager> podInfoManagerMock = new();
             Mock<IContainerStatusManager> containerStatusManagerMock = new();
             Mock<IK8sClientService> k8sClientServiceMock = new();
@@ -81,8 +79,8 @@ namespace Microsoft.ApplicationInsights.Kubernetes
                 }
             });
 
-            K8sEnvironmentFactory target = new K8sEnvironmentFactory(containerIdHolderMock.Object,
-                podInfoManagerMock.Object, containerStatusManagerMock.Object, k8sClientServiceMock.Object,
+            K8sEnvironmentFactory target = new K8sEnvironmentFactory(podInfoManagerMock.Object,
+                containerStatusManagerMock.Object, k8sClientServiceMock.Object,
                 appInsightsForKubernetesOptionsMock.Object);
 
             IK8sEnvironment environment = null;

--- a/tests/UnitTests/K8sEnvironemntFactoryTests.cs
+++ b/tests/UnitTests/K8sEnvironemntFactoryTests.cs
@@ -13,10 +13,8 @@ namespace Microsoft.ApplicationInsights.Kubernetes
 {
     public class K8sEnvironemntFactoryTests
     {
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async Task ShouldTimeoutWaitingPodReady(bool excludeNodeInformation)
+        [Fact]
+        public async Task ShouldTimeoutWaitingPodReady()
         {
             Mock<IPodInfoManager> podInfoManagerMock = new();
             Mock<IContainerStatusManager> containerStatusManagerMock = new();
@@ -24,7 +22,7 @@ namespace Microsoft.ApplicationInsights.Kubernetes
             Mock<IOptions<AppInsightsForKubernetesOptions>> appInsightsForKubernetesOptionsMock = new();
             appInsightsForKubernetesOptionsMock
                 .Setup(o => o.Value)
-                .Returns(new AppInsightsForKubernetesOptions { ExcludeNodeInformation = excludeNodeInformation });
+                .Returns(new AppInsightsForKubernetesOptions());
 
             // Timeout
             TimeSpan timeout = TimeSpan.FromMilliseconds(1);

--- a/tests/UnitTests/K8sEnvironemntFactoryTests.cs
+++ b/tests/UnitTests/K8sEnvironemntFactoryTests.cs
@@ -4,6 +4,8 @@ using System.Threading.Tasks;
 using k8s.Models;
 using Microsoft.ApplicationInsights.Kubernetes.Containers;
 using Microsoft.ApplicationInsights.Kubernetes.Pods;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
 
@@ -18,6 +20,7 @@ namespace Microsoft.ApplicationInsights.Kubernetes
             Mock<IPodInfoManager> podInfoManagerMock = new();
             Mock<IContainerStatusManager> containerStatusManagerMock = new();
             Mock<IK8sClientService> k8sClientServiceMock = new();
+            Mock<IOptions<AppInsightsForKubernetesOptions>> appInsightsForKubernetesOptionsMock = new();
 
             // Timeout
             TimeSpan timeout = TimeSpan.FromMilliseconds(1);
@@ -34,8 +37,9 @@ namespace Microsoft.ApplicationInsights.Kubernetes
                     }
                 });
 
-            K8sEnvironmentFactory target = new K8sEnvironmentFactory(containerIdHolderMock.Object, podInfoManagerMock.Object, containerStatusManagerMock.Object, k8sClientServiceMock.Object);
-
+            K8sEnvironmentFactory target = new K8sEnvironmentFactory(containerIdHolderMock.Object,
+                podInfoManagerMock.Object, containerStatusManagerMock.Object, k8sClientServiceMock.Object,
+                appInsightsForKubernetesOptionsMock.Object);
             IK8sEnvironment environment = null;
             CancellationToken timeoutToken;
             using (CancellationTokenSource timeoutSource = new CancellationTokenSource(TimeSpan.FromMilliseconds(1)))
@@ -56,6 +60,7 @@ namespace Microsoft.ApplicationInsights.Kubernetes
             Mock<IPodInfoManager> podInfoManagerMock = new();
             Mock<IContainerStatusManager> containerStatusManagerMock = new();
             Mock<IK8sClientService> k8sClientServiceMock = new();
+            Mock<IOptions<AppInsightsForKubernetesOptions>> appInsightsForKubernetesOptionsMock = new();
 
             // Timeout
             TimeSpan timeout = TimeSpan.FromMilliseconds(1);
@@ -76,7 +81,9 @@ namespace Microsoft.ApplicationInsights.Kubernetes
                 }
             });
 
-            K8sEnvironmentFactory target = new K8sEnvironmentFactory(containerIdHolderMock.Object, podInfoManagerMock.Object, containerStatusManagerMock.Object, k8sClientServiceMock.Object);
+            K8sEnvironmentFactory target = new K8sEnvironmentFactory(containerIdHolderMock.Object,
+                podInfoManagerMock.Object, containerStatusManagerMock.Object, k8sClientServiceMock.Object,
+                appInsightsForKubernetesOptionsMock.Object);
 
             IK8sEnvironment environment = null;
             CancellationToken timeoutToken;


### PR DESCRIPTION
Some companies do not allow all pods to call the nodes api in the cluster, 

Currently there is no way to skip the call to the nodes endpoint, which if you do not have the permission will potentially make noise in the logs showing a lot of failed (403 Forbidden) HTTP requests (see below). 
`K8sClientService.GetNodesAsync` ignores the forbidden response, by returning an empty `IEnumerable<V1Node>`, but the request is still being performed.

This change adds an option to `ExcludeNodeInformation`, which you can set to `true`, if you want to skip the call to nodes endpoint entirely - typically because you don't have permission (and likely won't get it) to call the endpoint.

<img width="790" height="272" alt="image" src="https://github.com/user-attachments/assets/476bd41b-73c6-4667-b2d5-10017aaf1a44" />
