### PR TITLE
Clamp Microsoft.ApplicationInsights to < 3.0.0 to prevent runtime crash

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -6,8 +6,8 @@
   <ItemGroup>
     <PackageVersion Include="KubernetesClient" Version="17.0.14" />
     <PackageVersion Include="MicroBuild.Core" Version="0.3.0" />
-    <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
-    <PackageVersion Include="Microsoft.ApplicationInsights" Version="2.23.0" />
+    <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="[2.23.0, 3.0.0)" />
+    <PackageVersion Include="Microsoft.ApplicationInsights" Version="[2.23.0, 3.0.0)" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.2" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.2" />
     <PackageVersion Include="Microsoft.Extensions.DiagnosticAdapter" Version="3.1.32" />


### PR DESCRIPTION
## Problem

Using `Microsoft.ApplicationInsights.AspNetCore` v3.0.0 alongside `Microsoft.ApplicationInsights.Kubernetes` v8.0.0 causes a runtime `TypeLoadException`:

```
System.TypeLoadException: Could not load type 'Microsoft.ApplicationInsights.Extensibility.ITelemetryInitializer'
from assembly 'Microsoft.ApplicationInsights, Version=3.0.0.1, ...'
```

This happens because `ITelemetryInitializer` was removed in Application Insights SDK 3.0.0.

## Fix

Added upper version bound `[2.23.0, 3.0.0)` on `Microsoft.ApplicationInsights` and `Microsoft.ApplicationInsights.AspNetCore` in `src/Directory.Packages.props`. Users who try to combine this library with AppInsights SDK 3.0.0 will now get a clear NuGet restore error instead of a cryptic runtime crash.

## Changes

- `src/Directory.Packages.props` — Version ranges updated from `2.23.0` to `[2.23.0, 3.0.0)`

## Verification

- Build succeeded ✅
- 80/80 unit tests passed ✅

Fixes #389